### PR TITLE
Add sensor node script and network helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ heartbeat packets over LoRa using the `pySX127x` library. The companion
 `network_monitor.py` listens for these heartbeats, logs them on the blockchain
 and prints a list of discovered nodes every minute.
 
-These scripts are stubs and can be run on a Raspberry Pi with appropriate radio
-modules attached.
+`sensor_node.py` polls a DHT22, soil moisture, pH, light and water level sensor
+every few seconds, stores the data on the blockchain and can optionally forward
+the payload over LoRa. These scripts are stubs and can be run on a Raspberry Pi
+with appropriate radio modules attached.
 
 ## Running a Fabric network
 
-This repository does not include the full Fabric test network. Refer to the official [Fabric documentation](https://hyperledger-fabric.readthedocs.io/) to bootstrap a network using the `test-network` samples. Deploy the chaincode in `chaincode/sensor` and update `hlf_client.py` to submit transactions via the Fabric SDK.
+This repository does not include the full Fabric test network. Refer to the official [Fabric documentation](https://hyperledger-fabric.readthedocs.io/) to bootstrap a network using the `test-network` samples. Deploy the chaincode in `chaincode/sensor` and update `hlf_client.py` to submit transactions via the Fabric SDK. The helper script `test_netwoek.sh` automates these steps by downloading the samples, starting the network and deploying the chaincode.
 
 ## Data tools and recovery demo
 

--- a/sensor_node.py
+++ b/sensor_node.py
@@ -1,0 +1,83 @@
+"""Sensor node that periodically records environmental data on chain."""
+
+import argparse
+import json
+import random
+import time
+from datetime import datetime
+
+import ipfshttpclient
+
+from flask_app.hlf_client import record_sensor_data
+
+# Importing the sx127x driver would require hardware. We keep a stub.
+class DummyLoRa:
+    def send(self, payload: bytes):
+        print("Sending:", payload)
+
+
+def read_dht22():
+    """Return dummy temperature and humidity readings."""
+    temp = random.uniform(20.0, 30.0)
+    hum = random.uniform(40.0, 70.0)
+    return temp, hum
+
+
+def read_soil_moisture():
+    return random.uniform(0.0, 100.0)
+
+
+def read_ph():
+    return random.uniform(5.5, 7.5)
+
+
+def read_light():
+    return random.uniform(0.0, 1023.0)
+
+
+def read_water_level():
+    return random.uniform(0.0, 100.0)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Sensor node")
+    parser.add_argument("device_id")
+    parser.add_argument("--interval", type=int, default=60,
+                        help="seconds between measurements")
+    parser.add_argument("--lora", action="store_true",
+                        help="forward readings over LoRa")
+    args = parser.parse_args()
+
+    client = ipfshttpclient.connect('/dns/localhost/tcp/5001/http')
+    lora = DummyLoRa() if args.lora else None
+
+    while True:
+        temp, hum = read_dht22()
+        soil = read_soil_moisture()
+        ph = read_ph()
+        light = read_light()
+        water = read_water_level()
+        timestamp = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+
+        payload = {
+            'id': args.device_id,
+            'temperature': temp,
+            'humidity': hum,
+            'soil_moisture': soil,
+            'ph': ph,
+            'light': light,
+            'water_level': water,
+            'timestamp': timestamp,
+        }
+        data = json.dumps(payload).encode('utf-8')
+        cid = client.add_bytes(data)
+        record_sensor_data(args.device_id, temp, hum, timestamp, cid)
+
+        if lora:
+            lora.send(data)
+
+        time.sleep(args.interval)
+
+
+if __name__ == '__main__':
+    main()

--- a/test_netwoek.sh
+++ b/test_netwoek.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Helper script to launch the Hyperledger Fabric test network with the
+# sensor chaincode. Run from the repository root on a Raspberry Pi.
+set -e
+
+# Download Fabric samples if not already present
+if [ ! -d fabric-samples/test-network ]; then
+    echo "Downloading Hyperledger Fabric samples..."
+    curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.5.0
+fi
+
+cd fabric-samples/test-network
+
+# Start the network and create a channel
+./network.sh up createChannel -ca
+
+# Deploy the sensor chaincode from this repository
+cp -r ../../chaincode/sensor ./chaincode/
+./network.sh deployCC -ccn sensor -ccp ./chaincode/sensor -ccl go
+
+echo "Fabric test network started with sensor chaincode deployed."


### PR DESCRIPTION
## Summary
- add `sensor_node.py` for polling sensors and writing data on chain
- include `test_netwoek.sh` helper script to start the Fabric test network
- document new utilities in README

## Testing
- `python -m py_compile sensor_node.py flask_app/app.py lora_node.py network_monitor.py tools/data_tool.py`


------
https://chatgpt.com/codex/tasks/task_e_685c05ef5f688320967c5cba96472be9