### PR TITLE
Add security monitoring sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,12 @@ python tools/block_inspector.py --block 2
 The inspector prints the block header including `previous_hash` and
 `data_hash`, allowing you to differentiate one block from another and
 view the stored transactions.
+
+## Security monitoring
+
+`threat_detection.py` continuously checks recent sensor readings for
+abnormal values. When it detects suspicious behaviour it records a
+security incident on the blockchain using the `LogSecurityIncident`
+chaincode function. `incident_responder.py` watches the ledger for such
+events and automatically quarantines affected devices via the stubbed
+`hlf_client` API.

--- a/flask_app/hlf_client.py
+++ b/flask_app/hlf_client.py
@@ -7,10 +7,20 @@
 # Keep a simple in-memory registry of devices so that the Flask app can
 # demonstrate interactions with multiple nodes without a real Fabric backend.
 DEVICES = []
+SENSOR_DATA = {}
+INCIDENTS = []
+ATTESTATIONS = []
 
 
 def record_sensor_data(id, temperature, humidity, timestamp, cid):
     """Submit RecordSensorData transaction."""
+    SENSOR_DATA[id] = {
+        'id': id,
+        'temperature': temperature,
+        'humidity': humidity,
+        'timestamp': timestamp,
+        'cid': cid,
+    }
     print(f"[HLF] record {id} {temperature} {humidity} {timestamp} {cid}")
 
 def register_device(id, owner):
@@ -24,23 +34,41 @@ def log_event(device_id, event_type, timestamp):
     print(f"[HLF] event {device_id} {event_type} {timestamp}")
 
 
+def log_security_incident(device_id, description, timestamp):
+    """Log a security incident on the ledger."""
+    INCIDENTS.append({
+        'device_id': device_id,
+        'description': description,
+        'timestamp': timestamp,
+    })
+    print(f"[HLF] security incident {device_id} {description} {timestamp}")
+
+
+def attest_device(device_id, status, timestamp):
+    """Record a device attestation result."""
+    ATTESTATIONS.append({
+        'device_id': device_id,
+        'status': status,
+        'timestamp': timestamp,
+    })
+    print(f"[HLF] attestation {device_id} {status} {timestamp}")
+
+
 def list_devices():
     """Return a list of registered device IDs."""
     # This would normally query the ledger. We return the in-memory list.
     return DEVICES
 
 
+def get_incidents():
+    """Return all recorded security incidents."""
+    return INCIDENTS
+
+
 def get_sensor_data(sensor_id):
     """Retrieve sensor metadata from the ledger."""
-    # In a real client this would query the ledger. Here we mock a response.
     print(f"[HLF] query sensor data for {sensor_id}")
-    return {
-        'id': sensor_id,
-        'temperature': 0,
-        'humidity': 0,
-        'timestamp': '1970-01-01T00:00:00Z',
-        'cid': 'QmExampleCID'
-    }
+    return SENSOR_DATA.get(sensor_id)
 
 
 def query_blockchain_info():
@@ -63,3 +91,17 @@ def get_block(block_number):
         },
         'data': []
     }
+
+
+QUARANTINED = set()
+
+
+def quarantine_device(device_id):
+    """Mark a device as quarantined."""
+    QUARANTINED.add(device_id)
+    print(f"[HLF] device {device_id} quarantined")
+
+
+def is_quarantined(device_id):
+    """Return True if the device is quarantined."""
+    return device_id in QUARANTINED

--- a/incident_responder.py
+++ b/incident_responder.py
@@ -1,0 +1,21 @@
+import time
+from flask_app.hlf_client import get_incidents, quarantine_device, is_quarantined
+
+
+def watch():
+    """Watch the ledger for incidents and quarantine devices."""
+    seen = set()
+    while True:
+        for inc in get_incidents():
+            key = (inc['device_id'], inc['timestamp'])
+            if key in seen:
+                continue
+            seen.add(key)
+            if not is_quarantined(inc['device_id']):
+                quarantine_device(inc['device_id'])
+        time.sleep(5)
+
+
+if __name__ == '__main__':
+    watch()
+

--- a/threat_detection.py
+++ b/threat_detection.py
@@ -1,0 +1,36 @@
+import time
+from datetime import datetime
+from flask_app.hlf_client import list_devices, get_sensor_data, log_security_incident
+
+THRESHOLDS = {
+    'temperature': (-10.0, 60.0),
+    'humidity': (0.0, 100.0),
+}
+
+def detect():
+    """Monitor devices and log security incidents."""
+    while True:
+        for dev in list_devices():
+            data = get_sensor_data(dev)
+            if not data:
+                continue
+            anomalies = []
+            t = data.get('temperature')
+            if t is not None:
+                lo, hi = THRESHOLDS['temperature']
+                if t < lo or t > hi:
+                    anomalies.append(f'temperature={t}')
+            h = data.get('humidity')
+            if h is not None:
+                lo, hi = THRESHOLDS['humidity']
+                if h < lo or h > hi:
+                    anomalies.append(f'humidity={h}')
+            if anomalies:
+                desc = 'anomaly: ' + ', '.join(anomalies)
+                ts = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+                log_security_incident(dev, desc, ts)
+        time.sleep(5)
+
+
+if __name__ == '__main__':
+    detect()


### PR DESCRIPTION
## Summary
- expand chaincode with security incident and attestation records
- simulate blockchain interactions in `hlf_client`
- add simple threat detection engine and automated incident responder
- document monitoring workflow in README

## Testing
- `python -m py_compile threat_detection.py incident_responder.py flask_app/*.py network_monitor.py lora_node.py sensor_node.py`


------
https://chatgpt.com/codex/tasks/task_e_685dc71084648320ae935e26fe8ed0e9