### PR TITLE
Add status dashboard for security incidents

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,9 @@ security incident on the blockchain using the `LogSecurityIncident`
 chaincode function. `incident_responder.py` watches the ledger for such
 events and automatically quarantines affected devices via the stubbed
 `hlf_client` API.
+
+The Flask dashboard also exposes a `/status` page showing the number of
+recorded security incidents and how many devices are currently quarantined.
+This information is refreshed live from the in-memory data maintained by
+`hlf_client` while `incident_responder` runs in the background when the
+web server starts.

--- a/flask_app/hlf_client.py
+++ b/flask_app/hlf_client.py
@@ -54,6 +54,11 @@ def attest_device(device_id, status, timestamp):
     print(f"[HLF] attestation {device_id} {status} {timestamp}")
 
 
+def get_attestations():
+    """Return recorded device attestations."""
+    return ATTESTATIONS
+
+
 def list_devices():
     """Return a list of registered device IDs."""
     # This would normally query the ledger. We return the in-memory list.
@@ -105,3 +110,8 @@ def quarantine_device(device_id):
 def is_quarantined(device_id):
     """Return True if the device is quarantined."""
     return device_id in QUARANTINED
+
+
+def get_quarantined():
+    """Return a list of quarantined device IDs."""
+    return list(QUARANTINED)


### PR DESCRIPTION
## Summary
- add helper functions to expose quarantined devices and attestations
- start background incident watcher when the Flask app runs
- provide `/status` and `/status-data` routes with a basic counter UI
- document the new status page in the README

## Testing
- `python -m py_compile flask_app/app.py flask_app/hlf_client.py incident_responder.py threat_detection.py network_monitor.py sensor_node.py tools/data_tool.py tools/block_inspector.py`

------
https://chatgpt.com/codex/tasks/task_e_685e0e11e5a483209cf5681e5bee80de