### PR TITLE
Add node recovery demo and history query

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,18 @@ Sensor readings and heartbeat events are submitted through chaincode
 committed to all peers. Clients can query the ledger to retrieve device
 information or verify data integrity.
 
+### Block characteristics
+
+Blocks in the default test network are cut when either 10 transactions
+accumulate or about two seconds pass.  A block typically stays under
+2&nbsp;MB in size but the absolute maximum is 10&nbsp;MB.  Every
+transaction is hashed with **SHA-256** before inclusion and the block
+header stores the Merkle root of all transaction hashes.  Communication
+between nodes is protected with TLS but the on-disk ledger itself is not
+encrypted.  Because only a small transaction descriptor is stored on the
+ledger, roughly a few hundred sensor events comfortably fit into a
+single block.
+
 ### Inspecting and verifying blocks
 
 The Fabric CLI can display high level ledger information:
@@ -166,3 +178,14 @@ recorded security incidents and how many devices are currently quarantined.
 This information is refreshed live from the in-memory data maintained by
 `hlf_client` while `incident_responder` runs in the background when the
 web server starts.
+
+## Data storage and recovery
+
+Sensor payloads are written to **IPFS**, giving each reading a content
+identifier (CID).  Only the CID and basic metadata are kept on the
+blockchain.  Every node can pin those CIDs to locally replicate the
+actual sensor files.  If a device or IPFS node fails, another node can
+retrieve the CIDs from the ledger and pin the data again.  The script
+`tools/node_recovery.py` automates this process for a freshly started
+node.  Once the historical CIDs are pinned the node continues to store
+new sensor data just like its peers.

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -15,6 +15,7 @@ from hlf_client import (
     get_sensor_data,
     get_sensor_history,
     get_all_sensor_data,
+    get_state_on,
     list_devices,
     get_block,
     get_incidents,
@@ -344,6 +345,13 @@ def export_data():
     resp.headers['Content-Disposition'] = 'attachment; filename="sensor_data.csv"'
     resp.headers['X-Data-Hash'] = h
     return resp
+
+
+@app.route('/state/<date>')
+def state_on(date):
+    """Return the last reading for each node on the given YYYY-MM-DD date."""
+    info = get_state_on(date)
+    return jsonify(info)
 
 
 @app.route('/verify-data', methods=['POST'])

--- a/flask_app/hlf_client.py
+++ b/flask_app/hlf_client.py
@@ -99,6 +99,18 @@ def get_all_sensor_data(start=None, end=None):
     return result
 
 
+def get_state_on(date: str):
+    """Return the last recorded reading for each device on the given YYYY-MM-DD date."""
+    result = {}
+    start = date + "T00:00:00Z"
+    end = date + "T23:59:59Z"
+    for dev in DEVICES:
+        records = get_sensor_history(dev, start, end)
+        if records:
+            result[dev] = records[-1]
+    return result
+
+
 def query_blockchain_info():
     """Return basic ledger info such as height and current block hash."""
     print("[HLF] query blockchain info")

--- a/tools/node_recovery.py
+++ b/tools/node_recovery.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Replicate sensor data for a new node joining the network."""
+
+import argparse
+import ipfshttpclient
+from flask_app import hlf_client
+
+
+def bootstrap(api_addr: str) -> None:
+    """Fetch all known sensor CIDs and pin them locally."""
+    client = ipfshttpclient.connect(api_addr)
+    for dev in hlf_client.list_devices():
+        for record in hlf_client.get_sensor_history(dev):
+            cid = record.get('cid')
+            if not cid:
+                continue
+            try:
+                client.pin.add(cid)
+                print(f"Pinned {cid} for {dev}")
+            except Exception as e:
+                print(f"Failed to pin {cid}: {e}")
+
+
+def main():
+    p = argparse.ArgumentParser(description="Recover data for a new storage node")
+    p.add_argument('--api', default='/dns/localhost/tcp/5001/http',
+                   help='IPFS API multiaddress of the new node')
+    args = p.parse_args()
+    bootstrap(args.api)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement `get_state_on()` helper to fetch daily node state
- expose `/state/<date>` endpoint in Flask app
- document block parameters, storage and recovery in README
- add `tools/node_recovery.py` demo script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e199f33108320a77edea8cb1e6102