### PR TITLE
Fix chaincode packaging error

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ This directory contains a minimal example of integrating Hyperledger Fabric with
 * Logging network events
 * Sending permissioned messages between devices
 
+The chaincode folder contains a `go.mod` file declaring its module path and
+dependencies. Hyperledger Fabric requires either Go modules or a `vendor`
+directory to package Go chaincode. The provided module file enables dependency
+vendoring before deploying the chaincode. The line `module sensor` simply
+names the chaincode module; it does not need to point to a real GitHub
+repository. The only external dependency is
+`github.com/hyperledger/fabric-contract-api-go`, which Go downloads when you
+run `go mod vendor`.
+
 ### Starting the blockchain and smart contract
 
 Launch the local Fabric network and deploy the sensor chaincode using the
@@ -78,6 +87,19 @@ The instructions below walk through a complete setup on a small Raspberry Pi clu
    curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.5.0
    ```
    This creates a `fabric-samples` directory containing the `test-network` sample.
+
+   The Go chaincode in `chaincode/sensor` uses Go modules. Before deploying the
+   chaincode, vendor its dependencies so that the Fabric peer does not attempt to
+   fetch them from the internet during packaging:
+   ```bash
+   cd chaincode/sensor
+   go mod vendor
+   cd ../../
+   ```
+
+   Without a `vendor` directory the `peer lifecycle chaincode package` command
+   executed by `test_network.sh` fails to create `sensor.tar.gz` and chaincode
+   installation stops with `failed to read chaincode package at 'sensor.tar.gz'`.
 
 4. **Start the network and deploy chaincode**
    From the repository root run:

--- a/chaincode/sensor/go.mod
+++ b/chaincode/sensor/go.mod
@@ -1,0 +1,9 @@
+// The module name does not need to reference an existing repository.
+// It simply identifies this chaincode for Go tooling.
+module sensor
+
+go 1.20
+
+require (
+    github.com/hyperledger/fabric-contract-api-go v1.1.0
+)

--- a/test_network.sh
+++ b/test_network.sh
@@ -9,6 +9,9 @@ if [ ! -d fabric-samples/test-network ]; then
     curl -sSL https://bit.ly/2ysbOFE | bash -s -- 2.5.0
 fi
 
+# Vendor Go dependencies so the peer can package the chaincode offline
+(cd chaincode/sensor && go mod vendor)
+
 cd fabric-samples/test-network
 
 # Ensure any previous test network is removed to prevent channel conflicts


### PR DESCRIPTION
## Summary
- document go module usage and vendoring requirements for the sensor chaincode
- explain what `module sensor` in `go.mod` means
- vendor dependencies automatically in `test_network.sh`

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*


------
https://chatgpt.com/codex/tasks/task_e_685ed45f2d908320b31d2a386d536249