### PR TITLE
Add threat detection engine and dashboard page

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,46 @@ This information is refreshed live from the in-memory data maintained by
 `hlf_client` while `incident_responder` runs in the background when the
 web server starts.
 
+## Threat Detection Engine (TDE)
+
+The Threat Detection Engine is the heart of the cybersecurity layer and is
+deployed directly on the Edge Gateway Node (e.g., Raspberry Pi). This engine
+continuously monitors device behavior to detect anomalies that may signify
+malicious activity.
+
+### Behavioral Baseline and Profiling
+
+Each sensor or actuator device has an expected pattern of behavior—defined by
+transmission intervals, data ranges, and communication protocols. The TDE builds
+a real-time behavioral model using a rolling average and standard deviation.
+
+### Lightweight Machine Learning
+
+For more advanced scenarios, a decision-tree classifier or anomaly detection
+algorithm like Isolation Forest is embedded in the gateway to learn patterns
+over time.
+
+Normal behavior: Regular sensor data within expected frequency
+
+Anomaly: Sudden surge of messages, invalid payloads, command injections
+
+These models continuously score each device with a Suspicion Score (0–1).
+Scores above a configurable threshold (e.g., 0.8) are treated as incidents.
+
+### Incident Generation
+
+Once a behavior is flagged, the engine generates a Security Incident Report
+(SIR) with metadata including:
+
+* Device ID
+* Type of anomaly
+* Time of detection
+* Suspicion score
+* Payload snapshot (optional)
+
+The report is serialized in JSON and forwarded to the blockchain via the smart
+contract interface.
+
 ## Data storage and recovery
 
 Sensor payloads are written to **IPFS**, giving each reading a content

--- a/addswnsor_connections.html
+++ b/addswnsor_connections.html
@@ -15,6 +15,7 @@
         <li class="nav-item"><a class="nav-link" href="/integrity">Data Integrity</a></li>
         <li class="nav-item"><a class="nav-link" href="/connect">Sensor Connection</a></li>
         <li class="nav-item"><a class="nav-link" href="/status">Network Status</a></li>
+        <li class="nav-item"><a class="nav-link" href="/tde">Threat Detection</a></li>
       </ul>
     </div>
   </nav>

--- a/data_integrity.html
+++ b/data_integrity.html
@@ -15,6 +15,7 @@
       <li class="nav-item"><a class="nav-link" href="/integrity">Data Integrity</a></li>
       <li class="nav-item"><a class="nav-link" href="/connect">Sensor Connection</a></li>
       <li class="nav-item"><a class="nav-link" href="/status">Network Status</a></li>
+      <li class="nav-item"><a class="nav-link" href="/tde">Threat Detection</a></li>
     </ul>
   </div>
 </nav>

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -165,6 +165,7 @@ def index():
                     <li class='nav-item'><a class='nav-link' href='/integrity'>Data Integrity</a></li>
                     <li class='nav-item'><a class='nav-link' href='/connect'>Sensor Connection</a></li>
                     <li class='nav-item'><a class='nav-link' href='/status'>Network Status</a></li>
+                    <li class='nav-item'><a class='nav-link' href='/tde'>Threat Detection</a></li>
                 </ul>
             </div>
         </nav>
@@ -459,6 +460,13 @@ def status_page():
 def connect_page():
     """Serve the sensor connection setup page."""
     template = Path(__file__).resolve().parent.parent / 'sensor_connection.html'
+    return render_template_string(template.read_text())
+
+
+@app.route('/tde')
+def tde_page():
+    """Show threat detection incidents."""
+    template = Path(__file__).resolve().parent.parent / 'threat_detection.html'
     return render_template_string(template.read_text())
 
 

--- a/flask_app/hlf_client.py
+++ b/flask_app/hlf_client.py
@@ -63,14 +63,19 @@ def log_event(device_id, event_type, timestamp):
     print(f"[HLF] event {device_id} {event_type} {timestamp}")
 
 
-def log_security_incident(device_id, description, timestamp):
+def log_security_incident(device_id, description, timestamp, *, score=None, payload=None):
     """Log a security incident on the ledger."""
-    INCIDENTS.append({
+    incident = {
         'device_id': device_id,
         'description': description,
         'timestamp': timestamp,
-    })
-    print(f"[HLF] security incident {device_id} {description} {timestamp}")
+    }
+    if score is not None:
+        incident['score'] = score
+    if payload is not None:
+        incident['payload'] = payload
+    INCIDENTS.append(incident)
+    print(f"[HLF] security incident {device_id} {description} {timestamp} score={score}")
 
 
 def attest_device(device_id, status, timestamp):

--- a/sensor_connection.html
+++ b/sensor_connection.html
@@ -15,6 +15,7 @@
         <li class="nav-item"><a class="nav-link" href="/integrity">Data Integrity</a></li>
         <li class="nav-item"><a class="nav-link" href="/connect">Sensor Connection</a></li>
         <li class="nav-item"><a class="nav-link" href="/status">Network Status</a></li>
+        <li class="nav-item"><a class="nav-link" href="/tde">Threat Detection</a></li>
       </ul>
     </div>
   </nav>

--- a/tde_engine.py
+++ b/tde_engine.py
@@ -1,0 +1,98 @@
+import math
+import json
+import time
+from collections import deque
+from datetime import datetime
+
+from flask_app.hlf_client import list_devices, get_sensor_data, log_security_incident
+
+
+class DeviceProfile:
+    """Maintain rolling stats for a device."""
+
+    def __init__(self, window=20):
+        self.window = window
+        self.intervals = deque(maxlen=window)
+        self.last_ts = None
+        self.temperature = deque(maxlen=window)
+        self.humidity = deque(maxlen=window)
+
+    def update(self, timestamp, temperature=None, humidity=None):
+        ts = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ")
+        if self.last_ts is not None:
+            self.intervals.append((ts - self.last_ts).total_seconds())
+        self.last_ts = ts
+        if temperature is not None:
+            self.temperature.append(float(temperature))
+        if humidity is not None:
+            self.humidity.append(float(humidity))
+
+    @staticmethod
+    def _stats(values):
+        if not values:
+            return 0.0, 0.0
+        avg = sum(values) / len(values)
+        var = sum((v - avg) ** 2 for v in values) / len(values)
+        return avg, math.sqrt(var)
+
+    def score(self, interval, temperature=None, humidity=None):
+        """Return a Suspicion Score between 0 and 1."""
+        score = 0.0
+        if interval is not None and len(self.intervals) >= 5:
+            avg, std = self._stats(self.intervals)
+            if std > 0 and abs(interval - avg) > 3 * std:
+                score = max(score, 0.5)
+        if temperature is not None and len(self.temperature) >= 5:
+            avg, std = self._stats(self.temperature)
+            if std > 0 and abs(temperature - avg) > 3 * std:
+                score = max(score, 0.7)
+        if humidity is not None and len(self.humidity) >= 5:
+            avg, std = self._stats(self.humidity)
+            if std > 0 and abs(humidity - avg) > 3 * std:
+                score = max(score, 0.7)
+        return min(score, 1.0)
+
+
+class ThreatDetectionEngine:
+    """Continuously monitor devices and report anomalies."""
+
+    def __init__(self, threshold=0.8):
+        self.threshold = threshold
+        self.profiles = {}
+
+    def process_reading(self, device_id, reading):
+        profile = self.profiles.setdefault(device_id, DeviceProfile())
+        ts = reading.get("timestamp")
+        temp = reading.get("temperature")
+        hum = reading.get("humidity")
+        interval = None
+        if profile.last_ts is not None:
+            dt = datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ")
+            interval = (dt - profile.last_ts).total_seconds()
+        suspicion = profile.score(interval, temp, hum)
+        profile.update(ts, temp, hum)
+        if suspicion >= self.threshold:
+            sir = {
+                "device_id": device_id,
+                "type": "behavior_anomaly",
+                "time": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "score": round(suspicion, 3),
+                "payload": reading,
+            }
+            log_security_incident(device_id, "behavior_anomaly", sir["time"], score=sir["score"], payload=reading)
+            print(json.dumps(sir))
+            return sir
+        return None
+
+    def run(self):
+        while True:
+            for dev in list_devices():
+                data = get_sensor_data(dev)
+                if not data:
+                    continue
+                self.process_reading(dev, data)
+            time.sleep(5)
+
+
+if __name__ == "__main__":
+    ThreatDetectionEngine().run()

--- a/threat_detection.html
+++ b/threat_detection.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Threat Detection</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.3/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <header class="bg-dark text-white text-center py-3 mb-4">
+    <h1>Hyperledger Farm Dashboard</h1>
+  </header>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+    <div class="container-fluid">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="/integrity">Data Integrity</a></li>
+        <li class="nav-item"><a class="nav-link" href="/connect">Sensor Connection</a></li>
+        <li class="nav-item"><a class="nav-link" href="/status">Network Status</a></li>
+        <li class="nav-item"><a class="nav-link active" aria-current="page" href="/tde">Threat Detection</a></li>
+      </ul>
+    </div>
+  </nav>
+  <div class="container py-4">
+    <h1 class="mb-3">Threat Detection</h1>
+    <table class="table" id="incidents">
+      <thead>
+        <tr><th>Device</th><th>Anomaly</th><th>Score</th><th>Time</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.3/js/bootstrap.bundle.min.js"></script>
+  <script>
+    async function loadIncidents(){
+      const res = await fetch('/status-data');
+      const data = await res.json();
+      const rows = data.incidents.map(i =>
+        `<tr><td>${i.device_id}</td><td>${i.description}</td><td>${i.score ?? ''}</td><td>${i.timestamp}</td></tr>`
+      ).join('');
+      document.querySelector('#incidents tbody').innerHTML = rows;
+    }
+    window.onload = loadIncidents;
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement `tde_engine.py` with rolling baseline and suspicion scoring
- store incident score and payload in `hlf_client.log_security_incident`
- add `/tde` route and `threat_detection.html` page to view incidents
- link new page from navigation menus
- document the Threat Detection Engine in `README.md`

## Testing
- `python -m py_compile tde_engine.py flask_app/app.py flask_app/hlf_client.py threat_detection.py incident_responder.py network_monitor.py sensor_node.py lora_node.py`

------
https://chatgpt.com/codex/tasks/task_e_685fdf87a7308320976fb8ba3db9f7e2