### PR TITLE
Add full sensor metrics to chaincode and clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This directory contains a minimal example of integrating Hyperledger Fabric with
 
 * Registering devices
 * Recording sensor data with IPFS CIDs
+  including soil moisture, pH, light
+  and water level measurements
 * Logging network events
 * Sending permissioned messages between devices
 
@@ -63,6 +65,8 @@ every few seconds. By default it sends the readings to the Flask API over HTTP
 but it can also transmit them over LoRa or use both channels for redundancy via
 the `--mode` option. These scripts are stubs and can be run on a Raspberry Pi
 with appropriate radio modules attached.
+The chaincode now records all of these metrics so that agronomists can
+track detailed conditions directly on the ledger.
 
 ## Connecting sensors to a Raspberry Pi
 

--- a/chaincode/sensor/sensor.go
+++ b/chaincode/sensor/sensor.go
@@ -11,11 +11,15 @@ type SmartContract struct {
 }
 
 type SensorData struct {
-	ID          string  `json:"id"`
-	Temperature float64 `json:"temperature"`
-	Humidity    float64 `json:"humidity"`
-	Timestamp   string  `json:"timestamp"`
-	CID         string  `json:"cid"`
+        ID          string  `json:"id"`
+        Temperature float64 `json:"temperature"`
+        Humidity    float64 `json:"humidity"`
+        SoilMoisture float64 `json:"soil_moisture"`
+        PH          float64 `json:"ph"`
+        Light       float64 `json:"light"`
+        WaterLevel  float64 `json:"water_level"`
+        Timestamp   string  `json:"timestamp"`
+        CID         string  `json:"cid"`
 }
 
 type Device struct {
@@ -71,7 +75,7 @@ func (s *SmartContract) deviceExists(ctx contractapi.TransactionContextInterface
 	return bytes != nil, nil
 }
 
-func (s *SmartContract) RecordSensorData(ctx contractapi.TransactionContextInterface, id string, temperature float64, humidity float64, timestamp string, cid string) error {
+func (s *SmartContract) RecordSensorData(ctx contractapi.TransactionContextInterface, id string, temperature float64, humidity float64, soilMoisture float64, ph float64, light float64, waterLevel float64, timestamp string, cid string) error {
 	exists, err := s.deviceExists(ctx, id)
 	if err != nil {
 		return err
@@ -79,7 +83,17 @@ func (s *SmartContract) RecordSensorData(ctx contractapi.TransactionContextInter
 	if !exists {
 		return fmt.Errorf("device not registered")
 	}
-	data := SensorData{ID: id, Temperature: temperature, Humidity: humidity, Timestamp: timestamp, CID: cid}
+        data := SensorData{
+                ID:          id,
+                Temperature: temperature,
+                Humidity:    humidity,
+                SoilMoisture: soilMoisture,
+                PH:          ph,
+                Light:       light,
+                WaterLevel:  waterLevel,
+                Timestamp:   timestamp,
+                CID:         cid,
+        }
 	bytes, err := json.Marshal(data)
 	if err != nil {
 		return err

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -373,8 +373,17 @@ def upload_file():
     res = client.add(file)
     cid = res['Hash']
     # Record the CID on the blockchain (stub implementation)
-    record_sensor_data(id=file.filename, temperature=0, humidity=0,
-                       timestamp=datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'), cid=cid)
+    record_sensor_data(
+        id=file.filename,
+        temperature=0,
+        humidity=0,
+        soil_moisture=0,
+        ph=0,
+        light=0,
+        water_level=0,
+        timestamp=datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+        cid=cid,
+    )
     return jsonify({'cid': cid})
 
 
@@ -556,6 +565,10 @@ def record_sensor():
         data.get('id', 'unknown'),
         float(data.get('temperature', 0)),
         float(data.get('humidity', 0)),
+        float(data.get('soil_moisture', 0)),
+        float(data.get('ph', 0)),
+        float(data.get('light', 0)),
+        float(data.get('water_level', 0)),
         data['timestamp'],
         cid,
     )

--- a/flask_app/hlf_client.py
+++ b/flask_app/hlf_client.py
@@ -35,8 +35,12 @@ def get_block_events():
     return BLOCK_EVENTS
 
 
-def record_sensor_data(id, temperature, humidity, timestamp, cid):
-    """Submit RecordSensorData transaction and keep a history of readings."""
+def record_sensor_data(id, temperature, humidity, soil_moisture, ph, light, water_level, timestamp, cid):
+    """Submit RecordSensorData transaction and keep a history of readings.
+
+    Parameters correspond to the fields stored by the chaincode, providing
+    a complete snapshot of environmental conditions.
+    """
     global CURRENT_BLOCK
     CURRENT_BLOCK += 1
     log_block_event(f"Creating block {CURRENT_BLOCK}")
@@ -46,11 +50,17 @@ def record_sensor_data(id, temperature, humidity, timestamp, cid):
         'id': id,
         'temperature': temperature,
         'humidity': humidity,
+        'soil_moisture': soil_moisture,
+        'ph': ph,
+        'light': light,
+        'water_level': water_level,
         'timestamp': timestamp,
         'cid': cid,
     }
     SENSOR_DATA.setdefault(id, []).append(entry)
-    print(f"[HLF] record {id} {temperature} {humidity} {timestamp} {cid}")
+    print(
+        f"[HLF] record {id} {temperature} {humidity} {soil_moisture} {ph} {light} {water_level} {timestamp} {cid}"
+    )
 
 def register_device(id, owner):
     """Register a device with the ledger."""

--- a/network_monitor.py
+++ b/network_monitor.py
@@ -31,11 +31,25 @@ def monitor():
                 node_id = data["id"]
                 known_nodes.add(node_id)
                 log_event(node_id, "heartbeat", data["timestamp"])
-            elif all(k in data for k in ("id", "temperature", "humidity", "timestamp", "cid")):
+            elif all(k in data for k in (
+                "id",
+                "temperature",
+                "humidity",
+                "soil_moisture",
+                "ph",
+                "light",
+                "water_level",
+                "timestamp",
+                "cid",
+            )):
                 record_sensor_data(
                     data["id"],
                     float(data["temperature"]),
                     float(data["humidity"]),
+                    float(data["soil_moisture"]),
+                    float(data["ph"]),
+                    float(data["light"]),
+                    float(data["water_level"]),
                     data["timestamp"],
                     data["cid"],
                 )

--- a/sensor_node.py
+++ b/sensor_node.py
@@ -83,7 +83,17 @@ def main():
         else:
             data = json.dumps(payload).encode('utf-8')
             cid = client.add_bytes(data)
-            record_sensor_data(args.device_id, temp, hum, timestamp, cid)
+            record_sensor_data(
+                args.device_id,
+                temp,
+                hum,
+                soil,
+                ph,
+                light,
+                water,
+                timestamp,
+                cid,
+            )
             payload['cid'] = cid
             data = json.dumps(payload).encode('utf-8')
 

--- a/tools/data_tool.py
+++ b/tools/data_tool.py
@@ -19,6 +19,10 @@ def upload(sensor_id: str, json_file: str):
         sensor_id,
         payload.get('temperature', 0),
         payload.get('humidity', 0),
+        payload.get('soil_moisture', 0),
+        payload.get('ph', 0),
+        payload.get('light', 0),
+        payload.get('water_level', 0),
         payload['timestamp'],
         cid,
     )


### PR DESCRIPTION
## Summary
- store soil moisture, pH, light and water level in SensorData
- update Flask app and client utilities to send the new fields
- extend network monitor and sensor node to record all metrics
- document additional data in the README

## Testing
- `python -m py_compile sensor_node.py network_monitor.py threat_detection.py incident_responder.py flask_app/*.py tools/*.py`
- `cd chaincode/sensor && go mod tidy && go mod vendor && go build ./...` *(build requires temporary vendoring)*

------
https://chatgpt.com/codex/tasks/task_e_687f4329cba883209b75371d8181c8e7