### PR TITLE
Add hierarchical network and CRT-based consensus simulation

### DIFF
--- a/PRECISION_AGRICULTURE_DESIGN.md
+++ b/PRECISION_AGRICULTURE_DESIGN.md
@@ -2,6 +2,36 @@
 
 This document outlines how to store 30 minute sensor summaries on-chain while keeping data volume small and ensuring cryptographic integrity. The approach relies on CRT compression, RSA-CRT signatures, and Hyperledger Fabric with PBFT consensus.
 
+## Phase 1: Network Architecture & Consensus
+
+### Farm Layout
+The pilot deployment targets a **1 km × 1 km** vegetable farm (100 hectares) divided into four equal quadrants. Each quadrant spans 500 m × 500 m and is treated as an independent zone for network routing and governance.
+
+### Device Mapping
+The network follows a hierarchical tree:
+
+```
+Farm Server (Central Receiver)
+├── Gateway-North
+│   ├── N1 … N25 sensor nodes
+├── Gateway-South
+│   ├── S1 … S25 sensor nodes
+├── Gateway-East
+│   ├── E1 … E25 sensor nodes
+└── Gateway-West
+    ├── W1 … W25 sensor nodes
+```
+
+Gateways sit at zone edges and aggregate traffic from their 25 associated sensors before forwarding results upstream.
+
+### Hierarchical Consensus
+1. The **farm server** initiates a collection round and broadcasts the request to all gateways.
+2. Each **gateway** relays the request to its sensors. Sensors measure, split the reading into CRT residues under small moduli (e.g., 101, 103, 107) and return the residues.
+3. Gateways validate residues locally and reach intra-zone consensus (majority acknowledgement) before forwarding them to the farm server.
+4. The **farm server** reconstructs the original values using the Chinese Remainder Theorem, verifies signatures, and assembles the final block.
+
+Using CRT keeps per-sensor state to just a few bytes, allowing parallel transactions and enabling memory-constrained IoT devices to participate in block validation.
+
 ## 1. Hardware Configuration
 - Raspberry Pi 4 (or similar SBC) as the edge node.
 - Install packages and clone edge processor:

--- a/hierarchical_consensus.py
+++ b/hierarchical_consensus.py
@@ -1,0 +1,83 @@
+"""Hierarchical network simulation for smart agriculture.
+
+Demonstrates how constrained IoT sensors can split readings into
+Chinese Remainder Theorem (CRT) residues and participate in a
+hierarchical consensus. Sensors send residues to zone gateways which
+forward validated values to the farm server for block creation.
+"""
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+MODULI = (101, 103, 107)  # pairwise coprime; residues fit in a byte
+
+def crt_split(value: float) -> List[int]:
+    scaled = int(value * 100)
+    return [scaled % m for m in MODULI]
+
+def crt_reconstruct(residues: List[int]) -> float:
+    M = 1
+    for m in MODULI:
+        M *= m
+    total = 0
+    for r, m in zip(residues, MODULI):
+        Mi = M // m
+        total += r * Mi * pow(Mi, -1, m)
+    return (total % M) / 100.0
+
+@dataclass
+class SensorNode:
+    sensor_id: str
+    gateway: "Gateway"
+
+    def submit(self, reading: float) -> None:
+        residues = crt_split(reading)
+        self.gateway.collect(self.sensor_id, residues)
+
+class Gateway:
+    def __init__(self, zone_id: str, server: "FarmServer") -> None:
+        self.zone_id = zone_id
+        self.server = server
+        self.pending: Dict[str, List[int]] = {}
+
+    def collect(self, sensor_id: str, residues: List[int]) -> None:
+        self.pending[sensor_id] = residues
+
+    def reach_consensus(self) -> None:
+        # Gateways could validate or average readings here.
+        for sensor_id, residues in self.pending.items():
+            self.server.receive(self.zone_id, sensor_id, residues)
+        self.pending.clear()
+
+class FarmServer:
+    def __init__(self) -> None:
+        self.received: Dict[Tuple[str, str], float] = {}
+
+    def receive(self, zone_id: str, sensor_id: str, residues: List[int]) -> None:
+        value = crt_reconstruct(residues)
+        self.received[(zone_id, sensor_id)] = value
+
+
+def build_farm() -> Tuple[List[SensorNode], List[Gateway], FarmServer]:
+    server = FarmServer()
+    zones = ["North", "South", "East", "West"]
+    gateways = [Gateway(zone, server) for zone in zones]
+    sensors: List[SensorNode] = []
+    for gw in gateways:
+        for idx in range(1, 6):  # five sensors per zone for demo
+            sensors.append(SensorNode(f"{gw.zone_id[0]}{idx}", gw))
+    return sensors, gateways, server
+
+def simulate() -> None:
+    sensors, gateways, server = build_farm()
+    # Sensors generate a sample reading and send residues
+    for sensor in sensors:
+        sensor.submit(23.75)
+    # Gateways validate/aggregate and forward to the farm server
+    for gw in gateways:
+        gw.reach_consensus()
+    # Farm server reconstructs original values
+    for (zone, sensor_id), value in server.received.items():
+        print(f"{zone}:{sensor_id} -> {value:.2f}")
+
+if __name__ == "__main__":
+    simulate()


### PR DESCRIPTION
## Summary
- Define farm layout and hierarchical consensus process using CRT residues in design doc
- Simulate CRT-based transaction flow from sensors to gateways to farm server

## Testing
- `python hierarchical_consensus.py`


------
https://chatgpt.com/codex/tasks/task_e_68974a5de1a48320be2997facdb0a120