### PR TITLE
centralize CRT residue helpers

### DIFF
--- a/advanced_consensus.py
+++ b/advanced_consensus.py
@@ -18,25 +18,10 @@ import heapq
 import hashlib
 from math import factorial
 
-from crt_parallel import crt_decompose, crt_reconstruct
-
-# pairwise coprime moduli for CRT residue handling
-MODULI = (101, 103, 107)
+from crt_utils import MODULI, crt_split, crt_value
 
 # explicit reliability target (e.g., 99.999%)
 RELIABILITY_TARGET = 0.99999
-
-
-def crt_split(value: float) -> List[int]:
-    """Split ``value`` into CRT residues scaled to two decimal places."""
-    scaled = int(value * 100)
-    return crt_decompose(scaled, MODULI)
-
-
-def crt_value(residues: List[int]) -> float:
-    """Reconstruct the original value from CRT residues."""
-    scaled = crt_reconstruct(residues, MODULI)
-    return scaled / 100.0
 
 
 def generate_snark_proof(residues: List[int]) -> str:

--- a/crt_utils.py
+++ b/crt_utils.py
@@ -1,0 +1,21 @@
+"""Shared utilities for handling sensor readings as CRT residues."""
+from typing import List
+from crt_parallel import crt_decompose, crt_reconstruct
+
+# Pairwise coprime moduli used across the project
+MODULI = (101, 103, 107)
+
+
+def crt_split(value: float) -> List[int]:
+    """Split ``value`` into CRT residues scaled to two decimal places."""
+    scaled = int(value * 100)
+    return crt_decompose(scaled, MODULI)
+
+
+def crt_value(residues: List[int]) -> float:
+    """Reconstruct the original value from CRT residues."""
+    scaled = crt_reconstruct(residues, MODULI)
+    return scaled / 100.0
+
+
+__all__ = ["MODULI", "crt_split", "crt_value"]

--- a/hierarchical_consensus.py
+++ b/hierarchical_consensus.py
@@ -18,22 +18,7 @@ hierarchical demo.
 from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
-from crt_parallel import crt_decompose, crt_reconstruct
-
-# Pairwise coprime moduli; residues fit in a byte
-MODULI = (101, 103, 107)
-
-
-def crt_split(value: float) -> List[int]:
-    """Return residues representing ``value`` to two decimal places."""
-    scaled = int(value * 100)
-    return crt_decompose(scaled, MODULI)
-
-
-def crt_value(residues: List[int]) -> float:
-    """Recover original value from residues produced by :func:`crt_split`."""
-    scaled = crt_reconstruct(residues, MODULI)
-    return scaled / 100.0
+from crt_utils import crt_split, crt_value
 
 @dataclass
 class SensorNode:


### PR DESCRIPTION
## Summary
- add `crt_utils` module with shared MODULI and residue helpers
- refactor consensus modules to reuse shared CRT utilities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899b07da778832083ac611a44863b23