### PR TITLE
Add sensor network simulator

### DIFF
--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -31,6 +31,7 @@ from hlf_client import (
 import threading
 from incident_responder import watch as incident_watch
 from nft_traceability import AgriNFT, MockBlockchain, verify_product
+from sensor_simulator import build_mapping
 
 app = Flask(__name__)
 
@@ -508,6 +509,26 @@ def connect_page():
     """Serve the sensor connection setup page."""
     template = Path(__file__).resolve().parent.parent / "sensor_connection.html"
     return render_template_string(template.read_text())
+
+
+@app.route("/simulate-ui")
+def simulator_page():
+    """Serve the sensor simulator page."""
+    template = Path(__file__).resolve().parent.parent / "sensor_simulator.html"
+    return render_template_string(template.read_text())
+
+
+@app.route("/simulate", methods=["POST"])
+def start_simulation():
+    """Launch the sensor simulator with the provided configuration."""
+    config = request.get_json() or {}
+    root = Path(__file__).resolve().parent.parent
+    cfg = root / "simulator_config.json"
+    cfg.write_text(json.dumps(config))
+    mapping = build_mapping(config)
+    script = root / "sensor_simulator.py"
+    subprocess.Popen(["python", str(script), str(cfg)])
+    return jsonify({"status": "started", "mapping": mapping})
 
 
 @app.route("/tde")

--- a/sensor_simulator.html
+++ b/sensor_simulator.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Sensor Simulator</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.3/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <header class="bg-dark text-white text-center py-3 mb-4">
+    <h1>AgriCrypt-Chain Farm Dashboard</h1>
+  </header>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+    <div class="container-fluid">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="/">Home</a></li>
+        <li class="nav-item"><a class="nav-link" href="/connect">Sensor Connection</a></li>
+        <li class="nav-item"><a class="nav-link active" href="/simulate-ui">Simulator</a></li>
+      </ul>
+    </div>
+  </nav>
+  <div class="container py-4">
+    <h1 class="mb-3">Test Sensor Simulator</h1>
+    <p class="mb-3">Configure virtual nodes and generate synthetic readings to test the system.</p>
+    <button class="btn btn-primary" onclick="startSim()">Start Simulation</button>
+    <pre id="mapping" class="bg-white border mt-3 p-3"></pre>
+  </div>
+  <script>
+  async function startSim(){
+    const nodeCount = parseInt(prompt('How many nodes?', '1'));
+    if(isNaN(nodeCount) || nodeCount < 1){ return; }
+    let nodes = [];
+    for(let i=0;i<nodeCount;i++){
+      const sensors = prompt(`Enter sensors for node ${i+1} (comma separated)`, 'dht22,soil,ph,light,water');
+      const sensorList = sensors ? sensors.split(',').map(s => s.trim()).filter(s => s) : [];
+      nodes.push({id:`node${i+1}`, sensors:sensorList});
+    }
+    const res = await fetch('/simulate', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({nodes})
+    });
+    const data = await res.json();
+    document.getElementById('mapping').textContent = JSON.stringify(data.mapping, null, 2);
+  }
+  </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.3/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/sensor_simulator.py
+++ b/sensor_simulator.py
@@ -1,0 +1,104 @@
+import json
+import random
+import sys
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+
+from flask_app.hlf_client import record_sensor_data, register_device
+
+GPIO_PINS = [4, 17, 27, 22, 5, 6, 13, 19, 26, 18, 23, 24, 25, 12, 16, 20, 21]
+
+
+def _simulate_sensor(sensor_id: str, node_id: str, gpio_pin: int) -> None:
+    """Send periodic fake readings for a single sensor."""
+    register_device(sensor_id, node_id)
+    while True:
+        temperature = round(random.uniform(10, 35), 2)
+        humidity = round(random.uniform(30, 90), 2)
+        soil_moisture = round(random.uniform(20, 80), 2)
+        ph = round(random.uniform(5.5, 7.5), 2)
+        light = round(random.uniform(200, 800), 2)
+        water_level = round(random.uniform(0, 100), 2)
+        ts = datetime.utcnow().isoformat()
+        record_sensor_data(
+            sensor_id,
+            temperature,
+            humidity,
+            soil_moisture,
+            ph,
+            light,
+            water_level,
+            ts,
+            {"gpio": gpio_pin, "simulated": True},
+        )
+        print(
+            f"{sensor_id} GPIO{gpio_pin} -> T:{temperature} H:{humidity} "
+            f"Soil:{soil_moisture} pH:{ph} Light:{light} Water:{water_level}"
+        )
+        time.sleep(5)
+
+
+def build_mapping(config: dict) -> dict:
+    """Return mapping of nodes to sensors and GPIO pins.
+
+    Exposed as a public function so the web application can reuse the same
+    logic when presenting GPIO assignments to the user before launching the
+    simulator.
+    """
+    mapping = {}
+    for node in config.get("nodes", []):
+        node_id = node.get("id")
+        sensors = {}
+        for idx, sensor in enumerate(node.get("sensors", [])):
+            gpio = GPIO_PINS[idx % len(GPIO_PINS)]
+            sensors[sensor] = gpio
+        mapping[node_id] = sensors
+    return mapping
+
+
+def main() -> None:
+    if len(sys.argv) > 1:
+        cfg_path = Path(sys.argv[1])
+        config = json.loads(cfg_path.read_text())
+    else:
+        nodes = int(input("How many nodes? "))
+        config = {"nodes": []}
+        for i in range(nodes):
+            sensors = (
+                input(f"Enter sensors for node {i + 1} (comma separated): ")
+                .split(",")
+            )
+            config["nodes"].append(
+                {
+                    "id": f"node{i + 1}",
+                    "sensors": [s.strip() for s in sensors if s.strip()],
+                }
+            )
+    mapping = build_mapping(config)
+    print("GPIO mapping:")
+    print(json.dumps(mapping, indent=2))
+
+    threads = []
+    for node_id, sensors in mapping.items():
+        for sensor_name, gpio_pin in sensors.items():
+            sensor_id = f"{node_id}_{sensor_name}"
+            t = threading.Thread(
+                target=_simulate_sensor,
+                args=(sensor_id, node_id, gpio_pin),
+                daemon=True,
+            )
+            t.start()
+            threads.append(t)
+
+    # Keep main thread alive
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sensor_simulator.py
+++ b/tests/test_sensor_simulator.py
@@ -1,0 +1,65 @@
+import sys
+import types
+
+import pytest
+
+# Stub out heavy dependencies imported by sensor_simulator
+hlf_client_stub = types.ModuleType("hlf_client")
+hlf_client_stub.record_sensor_data = lambda *args, **kwargs: None
+hlf_client_stub.register_device = lambda *args, **kwargs: None
+pkg = types.ModuleType("flask_app")
+pkg.hlf_client = hlf_client_stub
+sys.modules.setdefault("flask_app", pkg)
+sys.modules["flask_app.hlf_client"] = hlf_client_stub
+
+from sensor_simulator import build_mapping, GPIO_PINS
+
+
+def test_build_mapping_basic_multiple_nodes():
+    config = {
+        "nodes": [
+            {"id": "node1", "sensors": ["temp", "humidity"]},
+            {"id": "node2", "sensors": ["ph"]},
+        ]
+    }
+    mapping = build_mapping(config)
+    assert mapping == {
+        "node1": {"temp": GPIO_PINS[0], "humidity": GPIO_PINS[1]},
+        "node2": {"ph": GPIO_PINS[0]},
+    }
+
+
+def test_build_mapping_pin_wraps_when_exhausted():
+    sensor_count = len(GPIO_PINS) + 3
+    sensors = [f"s{i}" for i in range(sensor_count)]
+    config = {"nodes": [{"id": "node1", "sensors": sensors}]}
+    mapping = build_mapping(config)
+    assert mapping["node1"][f"s{len(GPIO_PINS)}"] == GPIO_PINS[0]
+    assert mapping["node1"][f"s{len(GPIO_PINS)+1}"] == GPIO_PINS[1]
+    assert mapping["node1"][f"s{len(GPIO_PINS)+2}"] == GPIO_PINS[2]
+
+
+def test_build_mapping_resets_for_each_node():
+    config = {
+        "nodes": [
+            {"id": "node1", "sensors": ["s1", "s2"]},
+            {"id": "node2", "sensors": ["s3", "s4"]},
+        ]
+    }
+    mapping = build_mapping(config)
+    assert mapping["node1"]["s1"] == GPIO_PINS[0]
+    assert mapping["node1"]["s2"] == GPIO_PINS[1]
+    assert mapping["node2"]["s3"] == GPIO_PINS[0]
+    assert mapping["node2"]["s4"] == GPIO_PINS[1]
+
+
+def test_build_mapping_handles_empty_sensor_lists():
+    config = {
+        "nodes": [
+            {"id": "node1", "sensors": []},
+            {"id": "node2", "sensors": ["only"]},
+        ]
+    }
+    mapping = build_mapping(config)
+    assert mapping["node1"] == {}
+    assert mapping["node2"]["only"] == GPIO_PINS[0]


### PR DESCRIPTION
## Summary
- Add standalone sensor simulator that generates fake readings and assigns GPIO pins
- Expose simulator controls via new `/simulate-ui` page and `/simulate` API endpoint
- Return and display GPIO mappings so users can see pin assignments before running nodes
- Add comprehensive tests for `build_mapping` covering multi-node setups and pin wrapping
- Reset GPIO assignments per node so one device can emulate an entire network

## Testing
- `python -m py_compile sensor_simulator.py tests/test_sensor_simulator.py`
- `python -m py_compile flask_app/app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899e09de1c88320ac9d662275dd7c05