### PR TITLE
Guard GOTOOLCHAIN usage in test network script

### DIFF
--- a/test_network.sh
+++ b/test_network.sh
@@ -107,7 +107,9 @@ ensure_go() {
 
   # make module cache writeable (prevents future permission hiccups)
   go env -w GOMODCACHE="${HOME}/go/pkg/mod"
-  go env -w GOTOOLCHAIN=local || true   # avoid auto-download surprises
+  if go env GOTOOLCHAIN >/dev/null 2>&1; then
+    go env -w GOTOOLCHAIN=local
+  fi                                   # avoid auto-download surprises
   export GOFLAGS=-modcacherw
 }
 


### PR DESCRIPTION
## Summary
- avoid `go env` error on older Go versions by checking for `GOTOOLCHAIN` support

## Testing
- `shellcheck test_network.sh`


------
https://chatgpt.com/codex/tasks/task_e_689b26d836008320ac6e1b93a9d5339e