### PR TITLE
Fix module import for Flask app and add requirements

### DIFF
--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -6,6 +6,12 @@ import subprocess
 import hashlib
 from pathlib import Path
 import io
+import sys
+
+# Ensure the project root is on the module search path so local modules
+# such as ``incident_responder`` can be imported when running this file
+# directly.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 # Placeholder for Hyperledger Fabric client imports
 import hlf_client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+cryptography==45.0.6
+Flask==3.1.1
+numpy==2.3.2
+pytest==8.4.1
+requests==2.32.4


### PR DESCRIPTION
## Summary
- ensure project root is added to `sys.path` so `incident_responder` can be imported by the Flask app
- add a `requirements.txt` listing core dependencies

## Testing
- `pytest`
- `python3 flask_app/app.py` *(fails: ImportError: cannot import name 'MockBlockchain' from 'nft_traceability')*

------
https://chatgpt.com/codex/tasks/task_e_689b8ff27c388320973542190e01d06c