### PR TITLE
Use correct Python executable when launching sensor simulator

### DIFF
--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -570,7 +570,9 @@ def start_simulation():
     cfg.write_text(json.dumps(config))
     mapping = build_mapping(config)
     script = root / "sensor_simulator.py"
-    subprocess.Popen(["python", str(script), str(cfg)])
+    # Use the current Python executable instead of a hard-coded "python" string
+    # to avoid FileNotFoundError on systems where only ``python3`` is installed.
+    subprocess.Popen([sys.executable, str(script), str(cfg)])
     return jsonify({"status": "started", "mapping": mapping})
 
 


### PR DESCRIPTION
## Summary
- Fix sensor simulator launch to use the current Python executable instead of hard-coded `python`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b9bf146d883209c8459d1f2c3cc42