### PR TITLE
Improve blockchain startup feedback and simulator persistence

### DIFF
--- a/sensor_simulator.html
+++ b/sensor_simulator.html
@@ -42,6 +42,14 @@
     const data = await res.json();
     document.getElementById('mapping').textContent = JSON.stringify(data.mapping, null, 2);
   }
+  async function loadMapping(){
+    const res = await fetch('/simulation-state');
+    const data = await res.json();
+    if(data.mapping){
+      document.getElementById('mapping').textContent = JSON.stringify(data.mapping, null, 2);
+    }
+  }
+  window.onload = loadMapping;
   </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.3/js/bootstrap.bundle.min.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Show explicit success or error messages when starting or restarting the blockchain
- Expose current sensor simulator mapping and display it on reload

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689baaca3a3c8320ad6788cd629c7261