### PR TITLE
Compress payload before RSA encryption

### DIFF
--- a/tests/test_hlf_client_encryption.py
+++ b/tests/test_hlf_client_encryption.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from flask_app.hlf_client import encrypt_payload, decrypt_payload
+
+
+def test_encrypt_decrypt_large_payload():
+    # Build a payload that would exceed RSA limits without compression
+    payload = {
+        "id": "sensor",
+        "data": "x" * 300,  # repeated data to push size over RSA block limit
+    }
+    enc = encrypt_payload(payload)
+    dec = decrypt_payload(enc)
+    assert dec == payload


### PR DESCRIPTION
## Summary
- Compress JSON payloads with zlib before RSA OAEP encryption to avoid hitting the key size limit and transparently decompress during decryption.
- Add regression test verifying large payloads can be encrypted and decrypted.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689baeb840dc832089e2fa01c00cd928