### PR TITLE
feat: show sensor-specific readings

### DIFF
--- a/history_view.html
+++ b/history_view.html
@@ -39,40 +39,58 @@
       const res = await fetch(url);
       return await res.json();
     }
-    function renderChart(labels, temps, hums){
+    const SENSOR_FIELDS = {
+      dht22: ['temperature','humidity'],
+      light: ['light'],
+      ph: ['ph'],
+      soil: ['soil_moisture'],
+      water: ['water_level']
+    };
+
+    function buildDatasets(id, records){
+      if(records.length === 0) return [];
+      const ignore = ['id', 'timestamp', 'payload'];
+      let keys = SENSOR_FIELDS[id];
+      if(!keys){
+        keys = Object.keys(records[0]).filter(k => !ignore.includes(k));
+      }
+      const colors = ['red','blue','green','orange','purple','brown','cyan'];
+      return keys.map((key, idx) => ({
+        label: key.replace('_', ' '),
+        data: records.map(r => r[key]),
+        borderColor: colors[idx % colors.length],
+        fill: false
+      }));
+    }
+
+    function renderChart(labels, datasets){
       if(chart){
         chart.data.labels = labels;
-        chart.data.datasets[0].data = temps;
-        chart.data.datasets[1].data = hums;
+        chart.data.datasets = datasets;
         chart.update();
       } else {
         chart = new Chart(document.getElementById('historyChart'), {
           type: 'line',
-          data: {
-            labels: labels,
-            datasets: [
-              {label: 'Temperature', data: temps, borderColor: 'red', fill: false},
-              {label: 'Humidity', data: hums, borderColor: 'blue', fill: false}
-            ]
-          }
+          data: { labels: labels, datasets: datasets }
         });
       }
     }
+
+    async function updateChart(id){
+      const d = await fetchHistory(id);
+      const labels = d.records.map(r => r.timestamp);
+      const datasets = buildDatasets(id, d.records);
+      renderChart(labels, datasets);
+    }
+
     async function init(){
       const data = await fetchHistory();
       const select = document.getElementById('sensorSelect');
       select.innerHTML = data.sensors.map(id => `<option value="${id}">${id}</option>`).join('');
-      select.addEventListener('change', async () => {
-        const d = await fetchHistory(select.value);
-        const labels = d.records.map(r => r.timestamp);
-        const temps = d.records.map(r => r.temperature);
-        const hums = d.records.map(r => r.humidity);
-        renderChart(labels, temps, hums);
-      });
+      select.addEventListener('change', () => updateChart(select.value));
       const labels = data.records.map(r => r.timestamp);
-      const temps = data.records.map(r => r.temperature);
-      const hums = data.records.map(r => r.humidity);
-      renderChart(labels, temps, hums);
+      const datasets = buildDatasets(select.value, data.records);
+      renderChart(labels, datasets);
     }
     window.onload = init;
   </script>


### PR DESCRIPTION
## Summary
- allow history view chart to display fields specific to selected sensor
- support dht22, light, ph, soil and water sensors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c738f963c83209be6ec752a8cbd9a