### PR TITLE
Add node diagnostics page and show simulator node IPs

### DIFF
--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -254,6 +254,7 @@ def index():
                     <li class='nav-item'><a class='nav-link' href='/devices'>Device Management</a></li>
                     <li class='nav-item'><a class='nav-link' href='/storage'>Storage Monitor</a></li>
                     <li class='nav-item'><a class='nav-link' href='/recovery'>Recovery</a></li>
+                    <li class='nav-item'><a class='nav-link' href='/diagnostics'>Node Diagnostics</a></li>
                     <li class='nav-item'><a class='nav-link' href='/access-log'>Access Log</a></li>
                 </ul>
             </div>
@@ -812,6 +813,12 @@ def verify_product_route(nft_id):
     except KeyError:
         return jsonify({"error": "NFT not found"}), 404
     return jsonify({"nft_id": nft_id, "result": result})
+
+
+@app.route("/diagnostics")
+def diagnostics_page():
+    template = Path(__file__).resolve().parent.parent / "node_diagnostics.html"
+    return render_template_string(template.read_text())
 
 
 @app.route("/access-log")

--- a/node_diagnostics.html
+++ b/node_diagnostics.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Node Diagnostics</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.3/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+  <header class="bg-dark text-white text-center py-3 mb-4">
+    <h1>AgriCrypt-Chain Farm Dashboard</h1>
+  </header>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+    <div class="container-fluid">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="/integrity">Data Integrity</a></li>
+        <li class="nav-item"><a class="nav-link" href="/connect">Sensor Connection</a></li>
+        <li class="nav-item"><a class="nav-link" href="/simulate-ui">Sensor Simulator</a></li>
+        <li class="nav-item"><a class="nav-link" href="/status">Network Status</a></li>
+        <li class="nav-item"><a class="nav-link" href="/tde">Threat Detection</a></li>
+        <li class="nav-item"><a class="nav-link" href="/history">Sensor History</a></li>
+        <li class="nav-item"><a class="nav-link" href="/explorer">Blockchain Explorer</a></li>
+        <li class="nav-item"><a class="nav-link" href="/devices">Device Management</a></li>
+        <li class="nav-item"><a class="nav-link" href="/storage">Storage Monitor</a></li>
+        <li class="nav-item"><a class="nav-link" href="/recovery">Recovery</a></li>
+        <li class="nav-item"><a class="nav-link" href="/access-log">Access Log</a></li>
+        <li class="nav-item"><a class="nav-link active" aria-current="page" href="/diagnostics">Node Diagnostics</a></li>
+      </ul>
+    </div>
+  </nav>
+  <div class="container py-4">
+    <h1 class="mb-3">Node Diagnostics</h1>
+    <p>Enter node endpoints (e.g., http://ip:port) one per line and click "Run Diagnostics" to test reachability.</p>
+    <div class="mb-3">
+      <textarea class="form-control" id="endpoints" rows="5" placeholder="http://192.168.0.1:8080\nhttp://192.168.0.2:8080"></textarea>
+    </div>
+    <button class="btn btn-primary" onclick="runDiagnostics()">Run Diagnostics</button>
+    <table class="table mt-4" id="results-table">
+      <thead>
+        <tr><th>Endpoint</th><th>Status</th></tr>
+      </thead>
+      <tbody id="results"></tbody>
+    </table>
+  </div>
+  <script>
+    async function runDiagnostics(){
+      const area = document.getElementById('endpoints');
+      const endpoints = area.value.split(/\n|,|;+/).map(e => e.trim()).filter(Boolean);
+      const tbody = document.getElementById('results');
+      tbody.innerHTML = '';
+      for(const ep of endpoints){
+        let status = 'unreachable';
+        try {
+          await fetch(ep, {method: 'HEAD', mode: 'no-cors'});
+          status = 'reachable';
+        } catch(err){
+          status = 'unreachable';
+        }
+        const row = document.createElement('tr');
+        row.innerHTML = `<td>${ep}</td><td>${status}</td>`;
+        tbody.appendChild(row);
+      }
+    }
+  </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.3/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/sensor_simulator.html
+++ b/sensor_simulator.html
@@ -22,6 +22,7 @@
     <h1 class="mb-3">Test Sensor Simulator</h1>
     <p class="mb-3">Configure virtual nodes and generate synthetic readings to test the system.</p>
     <button class="btn btn-primary" onclick="startSim()">Start Simulation</button>
+    <ul id="endpoints" class="mt-3"></ul>
     <pre id="mapping" class="bg-white border mt-3 p-3"></pre>
   </div>
   <script>
@@ -30,9 +31,10 @@
     if(isNaN(nodeCount) || nodeCount < 1){ return; }
     let nodes = [];
     for(let i=0;i<nodeCount;i++){
+      const ip = prompt(`Enter IP for node ${i+1}`, '192.168.0.100');
       const sensors = prompt(`Enter sensors for node ${i+1} (comma separated)`, 'dht22,soil,ph,light,water');
       const sensorList = sensors ? sensors.split(',').map(s => s.trim()).filter(s => s) : [];
-      nodes.push({id:`node${i+1}`, sensors:sensorList});
+      nodes.push({id:`node${i+1}`, ip, sensors:sensorList});
     }
     const res = await fetch('/simulate', {
       method:'POST',
@@ -41,13 +43,19 @@
     });
     const data = await res.json();
     document.getElementById('mapping').textContent = JSON.stringify(data.mapping, null, 2);
+    displayEndpoints(data.mapping);
   }
   async function loadMapping(){
     const res = await fetch('/simulation-state');
     const data = await res.json();
     if(data.mapping){
       document.getElementById('mapping').textContent = JSON.stringify(data.mapping, null, 2);
+      displayEndpoints(data.mapping);
     }
+  }
+  function displayEndpoints(mapping){
+    const list = Object.entries(mapping).map(([node, info]) => `<li>${node}: ${info.ip}</li>`).join('');
+    document.getElementById('endpoints').innerHTML = list;
   }
   window.onload = loadMapping;
   </script>

--- a/tests/test_sensor_simulator.py
+++ b/tests/test_sensor_simulator.py
@@ -24,8 +24,8 @@ def test_build_mapping_basic_multiple_nodes():
     }
     mapping = build_mapping(config)
     assert mapping == {
-        "node1": {"temp": GPIO_PINS[0], "humidity": GPIO_PINS[1]},
-        "node2": {"ph": GPIO_PINS[0]},
+        "node1": {"ip": "node1", "sensors": {"temp": GPIO_PINS[0], "humidity": GPIO_PINS[1]}},
+        "node2": {"ip": "node2", "sensors": {"ph": GPIO_PINS[0]}},
     }
 
 
@@ -34,9 +34,10 @@ def test_build_mapping_pin_wraps_when_exhausted():
     sensors = [f"s{i}" for i in range(sensor_count)]
     config = {"nodes": [{"id": "node1", "sensors": sensors}]}
     mapping = build_mapping(config)
-    assert mapping["node1"][f"s{len(GPIO_PINS)}"] == GPIO_PINS[0]
-    assert mapping["node1"][f"s{len(GPIO_PINS)+1}"] == GPIO_PINS[1]
-    assert mapping["node1"][f"s{len(GPIO_PINS)+2}"] == GPIO_PINS[2]
+    sensors_map = mapping["node1"]["sensors"]
+    assert sensors_map[f"s{len(GPIO_PINS)}"] == GPIO_PINS[0]
+    assert sensors_map[f"s{len(GPIO_PINS)+1}"] == GPIO_PINS[1]
+    assert sensors_map[f"s{len(GPIO_PINS)+2}"] == GPIO_PINS[2]
 
 
 def test_build_mapping_resets_for_each_node():
@@ -47,10 +48,10 @@ def test_build_mapping_resets_for_each_node():
         ]
     }
     mapping = build_mapping(config)
-    assert mapping["node1"]["s1"] == GPIO_PINS[0]
-    assert mapping["node1"]["s2"] == GPIO_PINS[1]
-    assert mapping["node2"]["s3"] == GPIO_PINS[0]
-    assert mapping["node2"]["s4"] == GPIO_PINS[1]
+    assert mapping["node1"]["sensors"]["s1"] == GPIO_PINS[0]
+    assert mapping["node1"]["sensors"]["s2"] == GPIO_PINS[1]
+    assert mapping["node2"]["sensors"]["s3"] == GPIO_PINS[0]
+    assert mapping["node2"]["sensors"]["s4"] == GPIO_PINS[1]
 
 
 def test_build_mapping_handles_empty_sensor_lists():
@@ -61,5 +62,5 @@ def test_build_mapping_handles_empty_sensor_lists():
         ]
     }
     mapping = build_mapping(config)
-    assert mapping["node1"] == {}
-    assert mapping["node2"]["only"] == GPIO_PINS[0]
+    assert mapping["node1"]["sensors"] == {}
+    assert mapping["node2"]["sensors"]["only"] == GPIO_PINS[0]


### PR DESCRIPTION
## Summary
- Serve node diagnostics page via Flask route
- Link dashboard navigation to node diagnostics
- Display simulated node endpoints and IPs in the sensor simulator

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c7e3bbd548320ba10f9d3d6997ac7