### PR TITLE
Improve sensor simulator node display

### DIFF
--- a/sensor_simulator.html
+++ b/sensor_simulator.html
@@ -54,7 +54,11 @@
     }
   }
   function displayEndpoints(mapping){
-    const list = Object.entries(mapping).map(([node, info]) => `<li>${node}: ${info.ip}</li>`).join('');
+    const list = Object.entries(mapping).map(([node, info]) => {
+      const ip = info.ip || 'N/A';
+      const sensors = info.sensors ? Object.keys(info.sensors).join(', ') : '';
+      return `<li>${node}: ${ip}${sensors ? ' (' + sensors + ')' : ''}</li>`;
+    }).join('');
     document.getElementById('endpoints').innerHTML = list;
   }
   window.onload = loadMapping;


### PR DESCRIPTION
## Summary
- Show sensor list and fallback when node IP is missing in simulator UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd2b06260832093f8bc1a66d637b4