### PR TITLE
Ensure simulator auto-configures IPs and sensors

### DIFF
--- a/node_broadcaster.py
+++ b/node_broadcaster.py
@@ -1,0 +1,32 @@
+import os
+import socket
+import requests
+
+APP_URL = os.environ.get("APP_URL", "https://localhost:8443")
+NODE_ID = os.environ.get("NODE_ID", "node")
+NODE_PORT = int(os.environ.get("NODE_PORT", "8000"))
+
+
+def _local_ip() -> str:
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+    except Exception:
+        ip = socket.gethostbyname(socket.gethostname())
+    finally:
+        s.close()
+    return ip
+
+
+def broadcast() -> None:
+    data = {"id": NODE_ID, "ip": _local_ip(), "port": NODE_PORT}
+    try:
+        requests.post(f"{APP_URL}/announce", json=data, timeout=5, verify=False)
+        print(f"Announced {NODE_ID} at {data['ip']}:{NODE_PORT}")
+    except Exception as exc:
+        print(f"Failed to announce: {exc}")
+
+
+if __name__ == "__main__":
+    broadcast()

--- a/sensor_simulator.html
+++ b/sensor_simulator.html
@@ -30,11 +30,13 @@
     const nodeCount = parseInt(prompt('How many nodes?', '1'));
     if(isNaN(nodeCount) || nodeCount < 1){ return; }
     let nodes = [];
+    const defaultSensors = 'dht22,soil,ph,light,water';
     for(let i=0;i<nodeCount;i++){
-      const ip = prompt(`Enter IP for node ${i+1}`, '192.168.0.100');
-      const sensors = prompt(`Enter sensors for node ${i+1} (comma separated)`, 'dht22,soil,ph,light,water');
-      const sensorList = sensors ? sensors.split(',').map(s => s.trim()).filter(s => s) : [];
-      nodes.push({id:`node${i+1}`, ip, sensors:sensorList});
+      const sensorsInput = prompt(`Enter sensors for node ${i+1} (comma separated)`, defaultSensors);
+      const sensorList = sensorsInput && sensorsInput.trim()
+        ? sensorsInput.split(',').map(s => s.trim()).filter(s => s)
+        : defaultSensors.split(',').map(s => s.trim());
+      nodes.push({id:`node${i+1}`, sensors:sensorList});
     }
     const res = await fetch('/simulate', {
       method:'POST',
@@ -55,9 +57,25 @@
   }
   function displayEndpoints(mapping){
     const list = Object.entries(mapping).map(([node, info]) => {
-      const ip = info.ip || 'N/A';
-      const sensors = info.sensors ? Object.keys(info.sensors).join(', ') : '';
-      return `<li>${node}: ${ip}${sensors ? ' (' + sensors + ')' : ''}</li>`;
+      let ip = node;
+      let port = '';
+      let sensors = [];
+      if(info && typeof info === 'object'){
+        if('ip' in info){
+          ip = info.ip || node;
+          if(info.port){
+            port = ':' + info.port;
+          }
+          if(info.sensors && typeof info.sensors === 'object'){
+            sensors = Object.keys(info.sensors);
+          }else{
+            sensors = Object.keys(info).filter(k => !['ip','port'].includes(k));
+          }
+        }else{
+          sensors = Object.keys(info);
+        }
+      }
+      return `<li>${node}: ${ip}${port}${sensors.length ? ' (' + sensors.join(', ') + ')' : ''}</li>`;
     }).join('');
     document.getElementById('endpoints').innerHTML = list;
   }

--- a/tests/test_sensor_simulator.py
+++ b/tests/test_sensor_simulator.py
@@ -1,5 +1,8 @@
 import sys
 import types
+import subprocess
+import importlib
+from pathlib import Path
 
 import pytest
 
@@ -12,21 +15,29 @@ pkg.hlf_client = hlf_client_stub
 sys.modules.setdefault("flask_app", pkg)
 sys.modules["flask_app.hlf_client"] = hlf_client_stub
 
-from sensor_simulator import build_mapping, GPIO_PINS
+from sensor_simulator import build_mapping, GPIO_PINS, DEFAULT_SENSORS
 
 
 def test_build_mapping_basic_multiple_nodes():
     config = {
         "nodes": [
             {"id": "node1", "sensors": ["temp", "humidity"]},
-            {"id": "node2", "sensors": ["ph"]},
+            {"id": "node2", "ip": "10.0.0.2", "sensors": ["ph"]},
         ]
     }
     mapping = build_mapping(config)
-    assert mapping == {
-        "node1": {"ip": "node1", "sensors": {"temp": GPIO_PINS[0], "humidity": GPIO_PINS[1]}},
-        "node2": {"ip": "node2", "sensors": {"ph": GPIO_PINS[0]}},
-    }
+    assert mapping["node2"]["ip"] == "10.0.0.2"
+    assert mapping["node1"]["sensors"] == {"temp": GPIO_PINS[0], "humidity": GPIO_PINS[1]}
+    assert mapping["node2"]["sensors"] == {"ph": GPIO_PINS[0]}
+    assert mapping["node1"]["ip"].startswith("192.168.0.")
+
+
+def test_build_mapping_generates_unique_ips():
+    config = {"nodes": [{"id": f"n{i}"} for i in range(1, 6)]}
+    mapping = build_mapping(config)
+    ips = [info["ip"] for info in mapping.values()]
+    assert len(set(ips)) == len(ips)
+    assert all(ip.startswith("192.168.0.") for ip in ips)
 
 
 def test_build_mapping_pin_wraps_when_exhausted():
@@ -62,5 +73,78 @@ def test_build_mapping_handles_empty_sensor_lists():
         ]
     }
     mapping = build_mapping(config)
-    assert mapping["node1"]["sensors"] == {}
+    expected_defaults = {s: GPIO_PINS[i] for i, s in enumerate(DEFAULT_SENSORS)}
+    assert mapping["node1"]["sensors"] == expected_defaults
     assert mapping["node2"]["sensors"]["only"] == GPIO_PINS[0]
+
+
+def test_simulation_updates_app_and_registers_devices(monkeypatch):
+    """Posting to /simulate should populate NODE_MAP and register sensors."""
+
+    # Remove the stubbed modules so the real Flask app can be imported
+    sys.modules.pop("flask_app", None)
+    sys.modules.pop("flask_app.hlf_client", None)
+    sys.modules.pop("hlf_client", None)
+    extra_path = str(Path(__file__).resolve().parents[1] / "flask_app")
+    sys.path.append(extra_path)
+    app_mod = importlib.import_module("flask_app.app")
+    import hlf_client
+
+    app_mod.NODE_MAP.clear()
+    hlf_client.DEVICES.clear()
+
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: None)
+    client = app_mod.app.test_client()
+    resp = client.post(
+        "/simulate",
+        json={"nodes": [{"id": "node1"}, {"id": "node2", "ip": "10.0.0.2", "sensors": ["ph"]}]},
+    )
+    assert resp.status_code == 200
+    mapping = resp.get_json()["mapping"]
+    assert app_mod.NODE_MAP == mapping
+
+    expected = {f"{n}_{s}" for n, info in mapping.items() for s in info["sensors"]}
+    assert set(hlf_client.DEVICES) >= expected
+
+    # Discover should now report the configured IPs
+    resp = client.post(
+        "/announce",
+        json={
+            "id": "node1",
+            "ip": mapping["node1"]["ip"],
+            "port": mapping["node1"].get("port", 8000),
+        },
+    )
+    assert resp.status_code == 200
+    resp = client.get("/discover")
+    info = resp.get_json()
+    ips = {n["ip"] for n in info["nodes"]}
+    assert {m["ip"] for m in mapping.values()} <= ips
+
+    # Clean up generated config file and globals
+    cfg = Path(__file__).resolve().parents[1] / "simulator_config.json"
+    if cfg.exists():
+        cfg.unlink()
+    hlf_client.DEVICES.clear()
+    app_mod.NODE_MAP.clear()
+    sys.path.remove(extra_path)
+
+
+def test_announce_endpoint_updates_node_map():
+    sys.modules.pop("flask_app", None)
+    sys.modules.pop("flask_app.hlf_client", None)
+    sys.modules.pop("hlf_client", None)
+    extra_path = str(Path(__file__).resolve().parents[1] / "flask_app")
+    sys.path.append(extra_path)
+    app_mod = importlib.import_module("flask_app.app")
+
+    client = app_mod.app.test_client()
+    resp = client.post(
+        "/announce", json={"id": "nodeA", "ip": "192.168.0.5", "port": 8123}
+    )
+    assert resp.status_code == 200
+    assert app_mod.NODE_MAP["nodeA"]["ip"] == "192.168.0.5"
+    assert app_mod.NODE_MAP["nodeA"]["port"] == 8123
+
+    app_mod.NODE_MAP.clear()
+    sys.path.remove(extra_path)


### PR DESCRIPTION
## Summary
- Generate unique 192.168.0.x addresses and ports for simulator nodes when not provided
- Allow physical nodes to announce their IP and port via new `/announce` endpoint
- Provide node broadcaster utility and update tests for automatic networking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd4a493108320856d48514b537422