### PR TITLE
Auto-activate test sensors

### DIFF
--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -36,6 +36,7 @@ from hlf_client import (
     get_state_on,
     get_latest_readings,
     list_devices,
+    list_active_devices,
     get_block,
     get_incidents,
     get_quarantined,
@@ -457,7 +458,7 @@ def discover():
     readings arrive.
     """
 
-    devices = list_devices()
+    devices = list_active_devices()
     if devices:
         grouped = _group_devices(devices)
         nodes = []

--- a/flask_app/hlf_client.py
+++ b/flask_app/hlf_client.py
@@ -12,9 +12,13 @@ from cryptography.hazmat.primitives import serialization
 # a Fabric network to invoke the sensor chaincode.
 # A real implementation would use the Fabric SDK to submit transactions.
 
-# Keep a simple in-memory registry of devices so that the Flask app can
-# demonstrate interactions with multiple nodes without a real Fabric backend.
+# Keep simple in-memory registries so the Flask app can demonstrate node
+# lifecycle events without a real Fabric backend.
 DEVICES = []
+# Track devices that have been promoted to active status.  In the testing
+# environment we automatically activate devices upon registration so sensors
+# appear in both the registered and active lists.
+ACTIVE_DEVICES = []
 # Mapping of sensor ID to a list of recorded readings
 SENSOR_DATA = {}
 INCIDENTS = []
@@ -124,7 +128,19 @@ def register_device(id, owner):
     """Register a device with the ledger."""
     if id not in DEVICES:
         DEVICES.append(id)
+    activate_device(id)
     print(f"[HLF] register device {id} owner {owner}")
+
+
+def activate_device(id):
+    """Mark a device as active if not already present."""
+    if id not in ACTIVE_DEVICES:
+        ACTIVE_DEVICES.append(id)
+
+
+def list_active_devices():
+    """Return a list of currently active device IDs."""
+    return ACTIVE_DEVICES
 
 
 def log_event(device_id, event_type, timestamp):

--- a/tests/test_sensor_simulator.py
+++ b/tests/test_sensor_simulator.py
@@ -6,6 +6,10 @@ from pathlib import Path
 
 import pytest
 
+# Ensure project root is importable when tests are executed from the tests
+# directory so modules like ``sensor_simulator`` can be resolved.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 # Stub out heavy dependencies imported by sensor_simulator
 hlf_client_stub = types.ModuleType("hlf_client")
 hlf_client_stub.record_sensor_data = lambda *args, **kwargs: None
@@ -105,6 +109,7 @@ def test_simulation_updates_app_and_registers_devices(monkeypatch):
 
     expected = {f"{n}_{s}" for n, info in mapping.items() for s in info["sensors"]}
     assert set(hlf_client.DEVICES) >= expected
+    assert set(hlf_client.ACTIVE_DEVICES) >= expected
 
     # Discover should now report the configured IPs
     resp = client.post(


### PR DESCRIPTION
## Summary
- track active devices alongside registered devices
- automatically activate sensors during registration and surface active nodes
- ensure tests import project root and verify active sensor promotion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cebfdd68083209158d9ddcbe284c6