### PR TITLE
Remove manual node discovery and use automatic node polling

### DIFF
--- a/sensor_connection.html
+++ b/sensor_connection.html
@@ -145,10 +145,14 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.2.3/js/bootstrap.bundle.min.js"></script>
   <script>
     async function loadNodes(){
-      const res = await fetch('/discover');
+      const res = await fetch('/nodes');
       const data = await res.json();
       const select = document.getElementById('node-select');
-      select.innerHTML = data.nodes.map(n => `<option value="${n.ip}">${n.ip}</option>`).join('');
+      const nodes = Array.isArray(data.nodes) ? data.nodes : [];
+      select.innerHTML = nodes.map(n => {
+        const ip = n.ip || n.id || n;
+        return `<option value="${ip}">${ip}</option>`;
+      }).join('');
     }
 
     document.getElementById('sensor-form').addEventListener('submit', function(e) {

--- a/tests/test_sensor_simulator.py
+++ b/tests/test_sensor_simulator.py
@@ -121,7 +121,7 @@ def test_simulation_updates_app_and_registers_devices(monkeypatch):
         },
     )
     assert resp.status_code == 200
-    resp = client.get("/discover")
+    resp = client.get("/nodes")
     info = resp.get_json()
     ips = {n["ip"] for n in info["nodes"]}
     assert {m["ip"] for m in mapping.values()} <= ips


### PR DESCRIPTION
## Summary
- replace active node discovery with automatic polling of registered nodes
- serve node data through `/nodes` including IPs and sensors
- update sensor connection page and tests to use `/nodes`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e1e9107b483209cd14a3fec58ab37