### PR TITLE
feat: allow simulator to use self-signed TLS cert

### DIFF
--- a/sensor_simulator.py
+++ b/sensor_simulator.py
@@ -14,10 +14,20 @@ import requests
 # Base URL of the running Flask application. Defaults to the local
 # development server but can be overridden via the ``SIMULATOR_URL``
 # environment variable so the simulator can target remote instances.
-BASE_URL = os.environ.get("SIMULATOR_URL", "https://localhost:8443")
-# Whether to verify TLS certificates when contacting the backend. Set
-# ``SIMULATOR_VERIFY=false`` to disable verification for self-signed dev certs.
-VERIFY = os.environ.get("SIMULATOR_VERIFY", "true").lower() != "false"
+# Using the explicit loopback address avoids hostname mismatches when the
+# development TLS certificate lacks a ``localhost`` subject.
+BASE_URL = os.environ.get("SIMULATOR_URL", "https://127.0.0.1:8443")
+
+# Path to a certificate authority bundle used to verify TLS connections.  When
+# ``SIMULATOR_CERT`` is provided the path is passed directly to ``requests`` so
+# self-signed development certificates can be trusted without globally
+# disabling verification.  Otherwise verification can be toggled via the
+# ``SIMULATOR_VERIFY`` flag.
+_CERT_PATH = os.environ.get("SIMULATOR_CERT")
+
+# Whether to verify TLS certificates when contacting the backend.  The value is
+# either the CA bundle path or a boolean depending on the environment.
+VERIFY = _CERT_PATH or os.environ.get("SIMULATOR_VERIFY", "true").lower() != "false"
 
 GPIO_PINS = [4, 17, 27, 22, 5, 6, 13, 19, 26, 18, 23, 24, 25, 12, 16, 20, 21]
 

--- a/start.md
+++ b/start.md
@@ -37,6 +37,11 @@ The dashboard will be available at `https://<host-ip>:8443/`.
 ## 6. Run the sensor simulator
 Use the simulator to send fake readings to the dashboard and ledger:
 ```bash
+# Trust the self-signed certificate generated above
+export SIMULATOR_CERT=cert.pem
+# Override the default URL or disable verification if necessary
+# export SIMULATOR_URL=https://<host-ip>:8443
+# export SIMULATOR_VERIFY=false
 python sensor_simulator.py
 ```
 The script prompts for the number of nodes and sensors, then continuously emits sample data.


### PR DESCRIPTION
## Summary
- default simulator to loopback address to avoid TLS hostname mismatches
- support SIMULATOR_CERT env var for verifying self-signed certificates
- document how to configure simulator environment variables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e23be87f48320a94a67f6531970a6