### PR TITLE
Add restart policies and persistent volumes to Fabric test network

### DIFF
--- a/docker-compose-test-net-override.yaml
+++ b/docker-compose-test-net-override.yaml
@@ -1,0 +1,48 @@
+# Override for Fabric test network: adds restart policies and persistent volumes
+
+version: '3.7'
+
+services:
+  orderer.example.com:
+    restart: unless-stopped
+    volumes:
+      - ../organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp:/var/hyperledger/orderer/msp
+      - ../organizations/ordererOrganizations/example.com/orderers/orderer.example.com/tls:/var/hyperledger/orderer/tls
+      - ${FABRIC_LEDGER_DIR}/orderer.example.com:/var/hyperledger/production/orderer
+
+  peer0.org1.example.com:
+    restart: unless-stopped
+    volumes:
+      - ../organizations/peerOrganizations/org1.example.com/peers/peer0.org1.example.com:/etc/hyperledger/fabric
+      - ${FABRIC_LEDGER_DIR}/peer0.org1.example.com:/var/hyperledger/production
+
+  peer0.org2.example.com:
+    restart: unless-stopped
+    volumes:
+      - ../organizations/peerOrganizations/org2.example.com/peers/peer0.org2.example.com:/etc/hyperledger/fabric
+      - ${FABRIC_LEDGER_DIR}/peer0.org2.example.com:/var/hyperledger/production
+
+  ca_org1:
+    restart: unless-stopped
+    volumes:
+      - ${FABRIC_LEDGER_DIR}/ca_org1:/etc/hyperledger/fabric-ca-server
+
+  ca_org2:
+    restart: unless-stopped
+    volumes:
+      - ${FABRIC_LEDGER_DIR}/ca_org2:/etc/hyperledger/fabric-ca-server
+
+  ca_orderer:
+    restart: unless-stopped
+    volumes:
+      - ${FABRIC_LEDGER_DIR}/ca_orderer:/etc/hyperledger/fabric-ca-server
+
+  couchdb0:
+    restart: unless-stopped
+    volumes:
+      - ${FABRIC_LEDGER_DIR}/couchdb0:/opt/couchdb/data
+
+  couchdb1:
+    restart: unless-stopped
+    volumes:
+      - ${FABRIC_LEDGER_DIR}/couchdb1:/opt/couchdb/data

--- a/start_network.sh
+++ b/start_network.sh
@@ -34,12 +34,20 @@ TEST_NET_DIR="${REPO_ROOT}/fabric-samples/test-network"
 CC_SENSOR="${REPO_ROOT}/chaincode/sensor"
 CC_AGRI="${REPO_ROOT}/chaincode/agri"
 
+# Ensure compose override is available and included
+OVERRIDE_COMPOSE="${TEST_NET_DIR}/compose/docker-compose-test-net-override.yaml"
+cp "${REPO_ROOT}/docker-compose-test-net-override.yaml" "${OVERRIDE_COMPOSE}" 2>/dev/null || true
+if ! grep -q "docker-compose-test-net-override.yaml" "${TEST_NET_DIR}/network.sh"; then
+  sed -i '/COMPOSE_FILES="-f compose\/${COMPOSE_FILE_BASE} -f compose\/${CONTAINER_CLI}\/${CONTAINER_CLI}-${COMPOSE_FILE_BASE}"/a\  COMPOSE_FILES="${COMPOSE_FILES} -f compose/docker-compose-test-net-override.yaml"' "${TEST_NET_DIR}/network.sh"
+fi
+
 # ---- Ledger storage ----
 LEDGER_DIR="${FABRIC_LEDGER_DIR:-${HOME}/fabric-ledger}"
-mkdir -p "${LEDGER_DIR}"/{orderer.example.com,peer0.org1.example.com,peer0.org2.example.com,couchdb0,couchdb1}
+mkdir -p "${LEDGER_DIR}"/{orderer.example.com,peer0.org1.example.com,peer0.org2.example.com,couchdb0,couchdb1,ca_org1,ca_org2,ca_orderer}
 uid="${SUDO_UID:-$(id -u)}"
 gid="${SUDO_GID:-$(id -g)}"
 chown -R "${uid}:${gid}" "${LEDGER_DIR}"
+export FABRIC_LEDGER_DIR="${LEDGER_DIR}"
 
 COMPOSE_TEST_NET="${TEST_NET_DIR}/compose/compose-test-net.yaml"
 COMPOSE_COUCH="${TEST_NET_DIR}/compose/compose-couch.yaml"

--- a/test_network.sh
+++ b/test_network.sh
@@ -133,12 +133,20 @@ if [[ ! -d "${TEST_NET_DIR}" ]]; then
   fi
 fi
 
+# Ensure compose override is available and included
+OVERRIDE_COMPOSE="${TEST_NET_DIR}/compose/docker-compose-test-net-override.yaml"
+cp "${REPO_ROOT}/docker-compose-test-net-override.yaml" "${OVERRIDE_COMPOSE}" 2>/dev/null || true
+if ! grep -q "docker-compose-test-net-override.yaml" "${TEST_NET_DIR}/network.sh"; then
+  sed -i '/COMPOSE_FILES="-f compose\/${COMPOSE_FILE_BASE} -f compose\/${CONTAINER_CLI}\/${CONTAINER_CLI}-${COMPOSE_FILE_BASE}"/a\  COMPOSE_FILES="${COMPOSE_FILES} -f compose/docker-compose-test-net-override.yaml"' "${TEST_NET_DIR}/network.sh"
+fi
+
 # ---- Ledger storage ----
 LEDGER_DIR="${FABRIC_LEDGER_DIR:-${HOME}/fabric-ledger}"
-mkdir -p "${LEDGER_DIR}"/{orderer.example.com,peer0.org1.example.com,peer0.org2.example.com,couchdb0,couchdb1}
+mkdir -p "${LEDGER_DIR}"/{orderer.example.com,peer0.org1.example.com,peer0.org2.example.com,couchdb0,couchdb1,ca_org1,ca_org2,ca_orderer}
 uid="$(id -u)"
 gid="$(id -g)"
 chown -R "${uid}:${gid}" "${LEDGER_DIR}"
+export FABRIC_LEDGER_DIR="${LEDGER_DIR}"
 
 COMPOSE_TEST_NET="${TEST_NET_DIR}/compose/compose-test-net.yaml"
 COMPOSE_COUCH="${TEST_NET_DIR}/compose/compose-couch.yaml"


### PR DESCRIPTION
## Summary
- Add Docker Compose override enabling auto-restart and host-mounted ledgers for orderer, peers, CAs, and CouchDB
- Wire override into network scripts and export ledger directory for container use

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a09cec54f48320985cb90b74033910