### PR TITLE
Always include compose override when starting network

### DIFF
--- a/start_network.sh
+++ b/start_network.sh
@@ -34,11 +34,13 @@ TEST_NET_DIR="${REPO_ROOT}/fabric-samples/test-network"
 CC_SENSOR="${REPO_ROOT}/chaincode/sensor"
 CC_AGRI="${REPO_ROOT}/chaincode/agri"
 
-# Ensure compose override is available and included
+# Ensure compose override is available and always used
 OVERRIDE_COMPOSE="${TEST_NET_DIR}/compose/docker-compose-test-net-override.yaml"
 cp "${REPO_ROOT}/docker-compose-test-net-override.yaml" "${OVERRIDE_COMPOSE}" 2>/dev/null || true
-if ! grep -q "docker-compose-test-net-override.yaml" "${TEST_NET_DIR}/network.sh"; then
-  sed -i '/COMPOSE_FILES="-f compose\/${COMPOSE_FILE_BASE} -f compose\/${CONTAINER_CLI}\/${CONTAINER_CLI}-${COMPOSE_FILE_BASE}"/a\  COMPOSE_FILES="${COMPOSE_FILES} -f compose/docker-compose-test-net-override.yaml"' "${TEST_NET_DIR}/network.sh"
+NETWORK_SCRIPT="${TEST_NET_DIR}/network.sh"
+if [[ -f "${NETWORK_SCRIPT}" ]] && ! grep -q "docker-compose-test-net-override.yaml" "${NETWORK_SCRIPT}"; then
+  cp "${NETWORK_SCRIPT}" "${NETWORK_SCRIPT}.bak"
+  sed -i '/COMPOSE_FILES="/s/"$/ -f compose\/docker-compose-test-net-override.yaml"/' "${NETWORK_SCRIPT}"
 fi
 
 # ---- Ledger storage ----

--- a/test_network.sh
+++ b/test_network.sh
@@ -133,11 +133,13 @@ if [[ ! -d "${TEST_NET_DIR}" ]]; then
   fi
 fi
 
-# Ensure compose override is available and included
+# Ensure compose override is available and always used
 OVERRIDE_COMPOSE="${TEST_NET_DIR}/compose/docker-compose-test-net-override.yaml"
 cp "${REPO_ROOT}/docker-compose-test-net-override.yaml" "${OVERRIDE_COMPOSE}" 2>/dev/null || true
-if ! grep -q "docker-compose-test-net-override.yaml" "${TEST_NET_DIR}/network.sh"; then
-  sed -i '/COMPOSE_FILES="-f compose\/${COMPOSE_FILE_BASE} -f compose\/${CONTAINER_CLI}\/${CONTAINER_CLI}-${COMPOSE_FILE_BASE}"/a\  COMPOSE_FILES="${COMPOSE_FILES} -f compose/docker-compose-test-net-override.yaml"' "${TEST_NET_DIR}/network.sh"
+NETWORK_SCRIPT="${TEST_NET_DIR}/network.sh"
+if [[ -f "${NETWORK_SCRIPT}" ]] && ! grep -q "docker-compose-test-net-override.yaml" "${NETWORK_SCRIPT}"; then
+  cp "${NETWORK_SCRIPT}" "${NETWORK_SCRIPT}.bak"
+  sed -i '/COMPOSE_FILES="/s/"$/ -f compose\/docker-compose-test-net-override.yaml"/' "${NETWORK_SCRIPT}"
 fi
 
 # ---- Ledger storage ----


### PR DESCRIPTION
## Summary
- ensure fabric test network always loads docker-compose-test-net-override.yaml
- back up network.sh before patching and append override compose file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0a307256883208752b0e13207b4fb