### PR TITLE
Add systemd unit for automatic Fabric start

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,26 @@ python tools/data_tool.py verify sensor-1
 
 These examples assume the chaincode has been deployed as described above. The dashboard offers buttons for verifying and recovering data using the same logic.
 
+## Starting the Fabric network at boot
+
+The `systemd/fabric-network@.service` unit lets any Linux user launch the Fabric test network automatically after reboot.
+
+1. Link the unit so your user picks up updates from this repository:
+   ```bash
+   systemctl --user link $(pwd)/systemd/fabric-network@.service
+   systemctl --user daemon-reload
+   ```
+2. Enable the service for the directory name where this repository resides (replace `$(basename "$PWD")` if needed):
+   ```bash
+   systemctl --user enable --now fabric-network@$(basename "$PWD").service
+   ```
+3. Allow the service to run without an active login:
+   ```bash
+   loginctl enable-linger $USER
+   ```
+
+The unit runs `start_network.sh` from the repository and passes `FABRIC_LEDGER_DIR` (default `~/fabric-ledger`) to persist the ledger. Adjust the directory name or ledger path with `systemctl --user edit` if your layout differs.
+
 ## Blockchain design
 
 This project uses **Hyperledger Fabric**, a permissioned blockchain platform. Peers

--- a/systemd/fabric-network@.service
+++ b/systemd/fabric-network@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Hyperledger Fabric test network in %h/%i
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/%i
+Environment=FABRIC_LEDGER_DIR=%h/fabric-ledger
+ExecStart=%h/%i/start_network.sh
+Restart=on-failure
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
- add templated user-level systemd service that runs `start_network.sh` with `FABRIC_LEDGER_DIR`
- document enabling the service and lingering for automatic boot startup
- refine unit to wait for network-online and link into user services

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0a59c7fa48320add7979faffdfb9b