### PR TITLE
Add idempotent identity enrollment helper

### DIFF
--- a/identity_enrollment.py
+++ b/identity_enrollment.py
@@ -1,0 +1,137 @@
+"""Utility functions for Hyperledger Fabric identity enrollment.
+
+This module provides a helper to ensure a peer node has valid MSP and TLS
+certificates by registering and enrolling with a Fabric Certificate
+Authority.  The process is designed to be idempotent: if existing
+certificates are present and not close to expiry, no network operations are
+performed.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import os
+import socket
+import subprocess
+from pathlib import Path
+from typing import Iterable, Optional
+
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+
+
+def _endpoint_up(endpoint: str, timeout: float = 5.0) -> bool:
+    """Return True if ``host:port`` is reachable via TCP."""
+    host, port = endpoint.split(":", 1)
+    try:
+        with socket.create_connection((host, int(port)), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _certificate_valid(cert_path: Path, min_validity: int = 3600) -> bool:
+    """Check that ``cert_path`` exists and is not expiring soon.
+
+    ``min_validity`` is the minimum number of seconds the certificate must
+    remain valid.  If the certificate is missing or invalid, ``False`` is
+    returned.
+    """
+    cert_file = Path(cert_path)
+    if not cert_file.exists():
+        return False
+    try:
+        cert = x509.load_pem_x509_certificate(cert_file.read_bytes(), default_backend())
+    except Exception:
+        return False
+    remaining = cert.not_valid_after - _dt.datetime.utcnow()
+    return remaining.total_seconds() > min_validity
+
+
+def enroll_identity(
+    node_name: str,
+    ca_url: str,
+    msp_dir: Path | str,
+    tls_dir: Path | str,
+    peer_endpoint: str,
+    orderer_endpoint: str,
+    *,
+    csr_hosts: Optional[Iterable[str]] = None,
+    secret: str = "pw",
+    min_validity: int = 3600,
+) -> bool:
+    """Ensure certificates for ``node_name`` exist and are valid.
+
+    Returns ``True`` if a (re-)enrollment was performed, ``False`` if the
+    existing certificates were deemed valid and no action was taken.
+    """
+
+    if not (_endpoint_up(peer_endpoint) and _endpoint_up(orderer_endpoint)):
+        raise RuntimeError("Network baseline is not alive")
+
+    msp_dir = Path(msp_dir)
+    tls_dir = Path(tls_dir)
+    msp_cert = msp_dir / "signcerts" / "cert.pem"
+    tls_cert = tls_dir / "server.crt"
+
+    if _certificate_valid(msp_cert, min_validity) and _certificate_valid(tls_cert, min_validity):
+        return False
+
+    msp_dir.mkdir(parents=True, exist_ok=True)
+    tls_dir.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env.setdefault("FABRIC_CA_CLIENT_HOME", str(msp_dir.parent))
+
+    # Register identity (idempotent; errors are ignored if already registered)
+    try:
+        subprocess.run(
+            [
+                "fabric-ca-client",
+                "register",
+                f"--id.name={node_name}",
+                f"--id.secret={secret}",
+                "--id.type=peer",
+                "-u",
+                ca_url,
+            ],
+            check=True,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError:
+        pass
+
+    # Enroll for MSP
+    subprocess.run(
+        [
+            "fabric-ca-client",
+            "enroll",
+            "-u",
+            f"http://{node_name}:{secret}@{ca_url}",
+            "-M",
+            str(msp_dir),
+        ],
+        check=True,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    # Enroll for TLS
+    tls_args = [
+        "fabric-ca-client",
+        "enroll",
+        "-u",
+        f"http://{node_name}:{secret}@{ca_url}",
+        "--enrollment.profile",
+        "tls",
+        "-M",
+        str(tls_dir),
+    ]
+    if csr_hosts:
+        tls_args.extend(["--csr.hosts", ",".join(csr_hosts)])
+    subprocess.run(tls_args, check=True, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    return True

--- a/tests/test_app_identity_enrollment.py
+++ b/tests/test_app_identity_enrollment.py
@@ -1,0 +1,70 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _stub(*args, **kwargs):
+    return None
+
+
+def test_ensure_admin_enrollment_invokes_enroll_identity(monkeypatch, tmp_path):
+    fake_client = types.ModuleType("hlf_client")
+    for name in [
+        "record_sensor_data",
+        "register_device",
+        "log_event",
+        "get_sensor_data",
+        "get_sensor_history",
+        "get_all_sensor_data",
+        "get_state_on",
+        "get_latest_readings",
+        "list_devices",
+        "get_block",
+        "get_incidents",
+        "get_quarantined",
+        "get_attestations",
+        "get_block_events",
+        "log_security_incident",
+        "attest_device",
+    ]:
+        setattr(fake_client, name, _stub)
+    monkeypatch.setitem(sys.modules, "hlf_client", fake_client)
+
+    fake_incident = types.ModuleType("incident_responder")
+    fake_incident.watch = _stub
+    monkeypatch.setitem(sys.modules, "incident_responder", fake_incident)
+
+    spec = importlib.util.spec_from_file_location("flask_app.app", Path("flask_app/app.py"))
+    app = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(app)  # type: ignore
+
+    calls = []
+
+    def fake_enroll(name, ca_url, msp_dir, tls_dir, peer_endpoint, orderer_endpoint, **kwargs):
+        calls.append(
+            {
+                "name": name,
+                "ca_url": ca_url,
+                "msp_dir": Path(msp_dir),
+                "tls_dir": Path(tls_dir),
+                "peer": peer_endpoint,
+                "orderer": orderer_endpoint,
+                "kwargs": kwargs,
+            }
+        )
+        return True
+
+    monkeypatch.setattr(app, "enroll_identity", fake_enroll)
+
+    net_dir = tmp_path
+    app.ensure_admin_enrollment(net_dir)
+
+    assert len(calls) == 2
+    first, second = calls
+    assert first["name"] == "admin"
+    assert first["ca_url"] == "http://localhost:7054"
+    assert first["msp_dir"] == net_dir / "organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp"
+    assert first["tls_dir"] == net_dir / "organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/tls"
+    assert second["ca_url"] == "http://localhost:8054"
+    assert second["peer"] == "peer0.org2.example.com:9051"

--- a/tests/test_identity_enrollment.py
+++ b/tests/test_identity_enrollment.py
@@ -1,0 +1,76 @@
+import subprocess
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from identity_enrollment import enroll_identity
+
+
+def _write_cert(path: Path, expire_after: int) -> None:
+    """Create a self-signed certificate at ``path`` valid for ``expire_after`` seconds."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test")])
+    now = datetime.utcnow()
+    
+    if expire_after >= 0:
+        not_before = now
+        not_after = now + timedelta(seconds=expire_after)
+    else:
+        not_after = now + timedelta(seconds=expire_after)
+        not_before = not_after - timedelta(days=1)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .sign(key, hashes.SHA256())
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+
+
+def test_enroll_skips_if_certificates_valid(tmp_path):
+    msp_dir = tmp_path / "msp"
+    tls_dir = tmp_path / "tls"
+    _write_cert(msp_dir / "signcerts" / "cert.pem", 86400)
+    _write_cert(tls_dir / "server.crt", 86400)
+
+    with patch("identity_enrollment._endpoint_up", return_value=True), patch("subprocess.run") as run_mock:
+        result = enroll_identity(
+            "peer0",
+            "http://ca:7054",
+            msp_dir,
+            tls_dir,
+            "peer.example.com:7051",
+            "orderer.example.com:7050",
+        )
+    assert result is False
+    run_mock.assert_not_called()
+
+
+def test_enroll_runs_when_certificate_missing(tmp_path):
+    msp_dir = tmp_path / "msp"
+    tls_dir = tmp_path / "tls"
+    _write_cert(msp_dir / "signcerts" / "cert.pem", -3600)  # expired
+
+    with patch("identity_enrollment._endpoint_up", return_value=True), patch("subprocess.run") as run_mock:
+        run_mock.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+        result = enroll_identity(
+            "peer0",
+            "http://ca:7054",
+            msp_dir,
+            tls_dir,
+            "peer.example.com:7051",
+            "orderer.example.com:7050",
+        )
+    assert result is True
+    assert run_mock.called


### PR DESCRIPTION
## Summary
- implement utility to register and enroll Fabric node identities while skipping when certificates are still valid
- link helper into Flask app so admin identities enroll automatically during system checks
- verify identity enrollment behavior with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1060dfc808320b6692da075eda948