### PR TITLE
Activate chaincodes after peer synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,13 @@ client traffic until synchronization completes:
 python peer_join_sync.py mychannel orderer.example.com:7050 tls/ca.crt mychannel.block
 ```
 
+After the peer's ledger catches up, the utility inspects the channel for any
+previously committed chaincodes. Each detected chaincode is queried once which
+launches its runtime container and serves as a lightweight health check. The
+peer is only marked ready for endorsements after all chaincodes respond,
+ensuring existing lifecycle definitions and endorsement policies remain
+unchanged.
+
 ## Blockchain design
 
 This project uses **Hyperledger Fabric**, a permissioned blockchain platform. Peers

--- a/tests/test_peer_join_sync_activation.py
+++ b/tests/test_peer_join_sync_activation.py
@@ -1,0 +1,42 @@
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import peer_join_sync
+
+
+def test_activate_committed_chaincodes_starts_and_marks(tmp_path):
+    ready = tmp_path / "ready.flag"
+    side_effects = [
+        subprocess.CompletedProcess(
+            ["peer", "lifecycle", "chaincode", "querycommitted"],
+            0,
+            stdout="Name: sensor, Version: 1, Sequence: 1\n",
+            stderr="",
+        ),
+        subprocess.CompletedProcess(
+            ["peer", "chaincode", "query"], 0, stdout="OK", stderr=""
+        ),
+    ]
+    with patch("peer_join_sync._run", side_effect=side_effects) as run_mock:
+        names = peer_join_sync.activate_committed_chaincodes("mychannel", ready)
+    assert names == ["sensor"]
+    assert ready.exists()
+    assert run_mock.call_count == 2
+
+
+def test_activate_committed_chaincodes_none(tmp_path):
+    ready = tmp_path / "ready.flag"
+    with patch(
+        "peer_join_sync._run",
+        return_value=subprocess.CompletedProcess(
+            ["peer", "lifecycle", "chaincode", "querycommitted"],
+            0,
+            stdout="",
+            stderr="",
+        ),
+    ) as run_mock:
+        names = peer_join_sync.activate_committed_chaincodes("mychannel", ready)
+    assert names == []
+    assert ready.exists()
+    run_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- Query committed chaincodes once the peer catches up and start their runtimes with a health check
- Mark the peer ready only after chaincode checks pass
- Document activation workflow in README and add unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a187ae5e588320a5c0a4056897118d