### PR TITLE
Refine node bootstrap automation and status reporting

### DIFF
--- a/bootstrap_config.json
+++ b/bootstrap_config.json
@@ -1,0 +1,12 @@
+{
+  "channel": "mychannel",
+  "orderer": "orderer.example.com:7050",
+  "ca_cert": "tls/ca.crt",
+  "ca_url": "https://ca.example.com:7054",
+  "node_name": "peer0.org1.example.com",
+  "peer_endpoint": "peer0.org1.example.com:7051",
+  "msp_dir": "msp",
+  "tls_dir": "tls",
+  "block_path": "mychannel.block",
+  "required_chaincodes": ["sensor", "supply"]
+}

--- a/node_bootstrap.py
+++ b/node_bootstrap.py
@@ -24,6 +24,10 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
+import subprocess
+import time
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
@@ -42,13 +46,50 @@ STATUS_FILE = Path("bootstrap_status.json")
 READY_FLAG = Path("peer.ready")
 
 
-def _write_status(status: Dict[str, Any]) -> None:
-    """Persist ``status`` to ``STATUS_FILE`` with an updated timestamp."""
+def _peer_version() -> str:
+    """Return the local peer binary version if available."""
+    try:
+        result = subprocess.run(
+            ["peer", "version"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for line in result.stdout.splitlines():
+            if line.startswith("Version:"):
+                return line.split("Version:", 1)[1].strip()
+    except Exception:  # noqa: BLE001
+        pass
+    return "unknown"
+
+
+@contextmanager
+def log_step(name: str):
+    """Context manager that logs start/end/duration of a bootstrap step."""
+    logger = logging.getLogger("bootstrap")
+    logger.info("start %s", name)
+    start = time.time()
+    try:
+        yield
+    except Exception:
+        duration = time.time() - start
+        logger.exception("error %s (%.2fs)", name, duration)
+        raise
+    else:
+        duration = time.time() - start
+        logger.info("end %s (%.2fs)", name, duration)
+
+
+def _write_status(status: Dict[str, Any], info: Dict[str, Any] | None = None) -> None:
+    """Persist ``status`` and optional ``info`` to ``STATUS_FILE``."""
     status = dict(status)
+    if info:
+        status.update(info)
     status["timestamp"] = datetime.utcnow().isoformat() + "Z"
     status["ready"] = all(
         status.get(k)
-        for k in ["ca_enrolled", "channel_joined", "ledger_synced", "chaincodes_healthy"]
+        for k in ["HAVE_IDENTITY", "JOINED_CHANNEL", "LEDGER_SYNCED", "CC_READY"]
     )
     STATUS_FILE.write_text(json.dumps(status, indent=2))
 
@@ -67,11 +108,25 @@ def bootstrap(args: argparse.Namespace) -> Dict[str, Any]:
     logger = logging.getLogger("bootstrap")
     logger.info("Starting node bootstrap")
 
+    os.environ.update(
+        {
+            "FABRIC_CHANNEL": args.channel,
+            "FABRIC_ORDERER": args.orderer,
+            "FABRIC_CA_URL": args.ca_url,
+            "FABRIC_PEER": args.peer_endpoint,
+        }
+    )
+
+    info = {
+        "endpoints": {"peer": args.peer_endpoint, "orderer": args.orderer},
+        "fabric_version": _peer_version(),
+    }
+
     status: Dict[str, Any] = {
-        "ca_enrolled": False,
-        "channel_joined": False,
-        "ledger_synced": False,
-        "chaincodes_healthy": False,
+        "HAVE_IDENTITY": False,
+        "JOINED_CHANNEL": False,
+        "LEDGER_SYNCED": False,
+        "CC_READY": False,
     }
 
     previous = _load_status()
@@ -81,90 +136,114 @@ def bootstrap(args: argparse.Namespace) -> Dict[str, Any]:
         logger.info("Prior successful state detected; performing verification")
         msp_cert = Path(args.msp_dir) / "signcerts" / "cert.pem"
         tls_cert = Path(args.tls_dir) / "server.crt"
-        status["ca_enrolled"] = _certificate_valid(msp_cert) and _certificate_valid(tls_cert)
+        status["HAVE_IDENTITY"] = _certificate_valid(msp_cert) and _certificate_valid(tls_cert)
         try:
-            wait_for_sync(args.channel, args.orderer, args.ca_cert, timeout=args.timeout)
-            status["ledger_synced"] = True
-            status["channel_joined"] = True  # implied by successful query
+            with log_step("ledger sync check"):
+                wait_for_sync(args.channel, args.orderer, args.ca_cert, timeout=args.timeout)
+            status["LEDGER_SYNCED"] = True
+            status["JOINED_CHANNEL"] = True
         except Exception as exc:  # noqa: BLE001
             logger.error("Ledger sync verification failed: %s", exc)
         try:
-            activate_committed_chaincodes(args.channel, READY_FLAG)
-            status["chaincodes_healthy"] = True
+            with log_step("chaincode health check"):
+                activate_committed_chaincodes(args.channel, READY_FLAG)
+            status["CC_READY"] = True
         except Exception as exc:  # noqa: BLE001
             logger.error("Chaincode health check failed: %s", exc)
-        _write_status(status)
+        _write_status(status, info)
         return status
 
     # ---- Full bootstrap ----
     try:
-        logger.info("Enrolling identity via CA")
-        enroll_identity(
-            args.node_name,
-            args.ca_url,
-            args.msp_dir,
-            args.tls_dir,
-            args.peer_endpoint,
-            args.orderer,
-            csr_hosts=args.csr_hosts,
-        )
-        status["ca_enrolled"] = True
+        with log_step("enroll identity"):
+            enroll_identity(
+                args.node_name,
+                args.ca_url,
+                args.msp_dir,
+                args.tls_dir,
+                args.peer_endpoint,
+                args.orderer,
+                csr_hosts=args.csr_hosts,
+            )
+        status["HAVE_IDENTITY"] = True
     except Exception as exc:  # noqa: BLE001
         logger.exception("CA enrollment failed: %s", exc)
-        _write_status(status)
+        _write_status(status, info)
         return status
 
     try:
-        logger.info("Fetching channel block and joining peer")
-        fetch_channel_block(args.channel, args.orderer, args.ca_cert, args.block_path)
-        join_channel(args.block_path)
-        status["channel_joined"] = True
+        with log_step("join channel"):
+            fetch_channel_block(args.channel, args.orderer, args.ca_cert, args.block_path)
+            join_channel(args.block_path)
+        status["JOINED_CHANNEL"] = True
     except Exception as exc:  # noqa: BLE001
         logger.exception("Channel join failed: %s", exc)
-        _write_status(status)
+        _write_status(status, info)
         return status
 
     try:
-        logger.info("Waiting for ledger to synchronize")
-        wait_for_sync(
-            args.channel,
-            args.orderer,
-            args.ca_cert,
-            interval=args.interval,
-            timeout=args.timeout,
-        )
-        status["ledger_synced"] = True
+        with log_step("ledger sync"):
+            wait_for_sync(
+                args.channel,
+                args.orderer,
+                args.ca_cert,
+                interval=args.interval,
+                timeout=args.timeout,
+            )
+        status["LEDGER_SYNCED"] = True
     except Exception as exc:  # noqa: BLE001
         logger.exception("Ledger synchronization failed: %s", exc)
-        _write_status(status)
+        _write_status(status, info)
         return status
 
     try:
-        logger.info("Activating committed chaincodes")
-        activate_committed_chaincodes(args.channel, READY_FLAG)
-        status["chaincodes_healthy"] = True
+        with log_step("activate chaincodes"):
+            activate_committed_chaincodes(args.channel, READY_FLAG)
+        status["CC_READY"] = True
     except Exception as exc:  # noqa: BLE001
         logger.exception("Chaincode activation failed: %s", exc)
 
-    _write_status(status)
+    _write_status(status, info)
     return status
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Bootstrap a Fabric peer node")
-    parser.add_argument("channel", help="Channel name to join")
-    parser.add_argument("orderer", help="Orderer endpoint (host:port)")
-    parser.add_argument("ca_cert", help="Path to orderer TLS CA cert")
-    parser.add_argument("ca_url", help="URL of certificate authority")
-    parser.add_argument("node_name", help="Identity to enroll with the CA")
-    parser.add_argument("peer_endpoint", help="Host:port of the local peer")
-    parser.add_argument("msp_dir", help="Directory for MSP materials")
-    parser.add_argument("tls_dir", help="Directory for TLS materials")
-    parser.add_argument("block_path", help="Where to store the channel block")
+    parser.add_argument("--config", help="Path to JSON configuration", default=None)
+    parser.add_argument("--channel", help="Channel name to join")
+    parser.add_argument("--orderer", help="Orderer endpoint (host:port)")
+    parser.add_argument("--ca_cert", help="Path to orderer TLS CA cert")
+    parser.add_argument("--ca_url", help="URL of certificate authority")
+    parser.add_argument("--node_name", help="Identity to enroll with the CA")
+    parser.add_argument("--peer_endpoint", help="Host:port of the local peer")
+    parser.add_argument("--msp_dir", help="Directory for MSP materials")
+    parser.add_argument("--tls_dir", help="Directory for TLS materials")
+    parser.add_argument("--block_path", help="Where to store the channel block")
     parser.add_argument("--csr-hosts", nargs="*", default=None, help="Hosts for TLS CSR")
     parser.add_argument("--interval", type=float, default=5.0, help="Seconds between height checks")
     parser.add_argument("--timeout", type=float, default=300.0, help="Max seconds to wait for sync")
     args = parser.parse_args()
+
+    if args.config:
+        data = json.loads(Path(args.config).read_text())
+        for key, value in data.items():
+            if getattr(args, key, None) is None:
+                setattr(args, key, value)
+
+    required = [
+        "channel",
+        "orderer",
+        "ca_cert",
+        "ca_url",
+        "node_name",
+        "peer_endpoint",
+        "msp_dir",
+        "tls_dir",
+        "block_path",
+    ]
+    missing = [k for k in required if getattr(args, k, None) is None]
+    if missing:
+        parser.error("Missing required parameters: " + ", ".join(missing))
 
     logging.basicConfig(
         level=logging.INFO,

--- a/tests/test_node_bootstrap_status.py
+++ b/tests/test_node_bootstrap_status.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+import node_bootstrap
+
+
+def test_write_status_ready(tmp_path, monkeypatch):
+    dest = tmp_path / "status.json"
+    monkeypatch.setattr(node_bootstrap, "STATUS_FILE", dest)
+    status = {
+        "HAVE_IDENTITY": True,
+        "JOINED_CHANNEL": True,
+        "LEDGER_SYNCED": True,
+        "CC_READY": True,
+    }
+    node_bootstrap._write_status(status)
+    data = json.loads(dest.read_text())
+    assert data["ready"] is True


### PR DESCRIPTION
## Summary
- allow node bootstrap configuration via JSON file
- record readiness flags (HAVE_IDENTITY, JOINED_CHANNEL, LEDGER_SYNCED, CC_READY) with health metadata and structured logging
- add unit test for status writer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1912ad3a083208de3b4d8dfbff884