### PR TITLE
Serialize device writes and add gateway store-and-forward

### DIFF
--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -971,6 +971,12 @@ def verify_data():
     return jsonify({"verified": uploaded_hash == expected_hash})
 
 
+@app.route("/backlog")
+def backlog_stats():
+    """Expose counts of buffered readings per device."""
+    return jsonify(hlf_client.get_backlog_stats())
+
+
 @app.route("/sensor", methods=["POST"])
 def record_sensor():
     if request.is_json:

--- a/tests/test_gateway_serialization.py
+++ b/tests/test_gateway_serialization.py
@@ -1,0 +1,65 @@
+import threading
+import time
+import importlib.util
+from pathlib import Path
+
+
+spec = importlib.util.spec_from_file_location("hlf_client", Path("flask_app/hlf_client.py"))
+hlf = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hlf)
+
+
+def test_per_device_serialization(monkeypatch, tmp_path):
+    # use temporary backlog directory and disable retry timers for determinism
+    monkeypatch.setattr(hlf, "BACKLOG_DIR", tmp_path)
+    monkeypatch.setattr(hlf, "_schedule_retry", lambda device_id: None)
+
+    processed = []
+
+    def fake_send(*args):
+        # append sequence to verify ordering
+        processed.append(args[1])
+
+    monkeypatch.setattr(hlf, "_record_sensor_data_direct", fake_send)
+
+    threads = []
+    for seq in range(5):
+        t = threading.Thread(
+            target=hlf.record_sensor_data,
+            args=("dev", seq, 0, 0, 0, 0, 0, 0, "t", {}),
+        )
+        threads.append(t)
+        t.start()
+    for t in threads:
+        t.join()
+    # wait for worker to finish
+    hlf.DEVICE_QUEUES["dev"].join()
+
+    assert processed == list(range(5))
+
+
+def test_parallel_across_devices(monkeypatch, tmp_path):
+    monkeypatch.setattr(hlf, "BACKLOG_DIR", tmp_path)
+    monkeypatch.setattr(hlf, "_schedule_retry", lambda device_id: None)
+
+    def fake_send(*args):
+        time.sleep(0.1)
+
+    monkeypatch.setattr(hlf, "_record_sensor_data_direct", fake_send)
+
+    start = time.time()
+    t1 = threading.Thread(
+        target=hlf.record_sensor_data, args=("a", 1, 0, 0, 0, 0, 0, 0, "t", {})
+    )
+    t2 = threading.Thread(
+        target=hlf.record_sensor_data, args=("b", 1, 0, 0, 0, 0, 0, 0, "t", {})
+    )
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+    hlf.DEVICE_QUEUES["a"].join()
+    hlf.DEVICE_QUEUES["b"].join()
+    duration = time.time() - start
+
+    assert duration < 0.2

--- a/tests/test_store_and_forward.py
+++ b/tests/test_store_and_forward.py
@@ -1,0 +1,34 @@
+import importlib.util
+from pathlib import Path
+
+
+spec = importlib.util.spec_from_file_location("hlf_client", Path("flask_app/hlf_client.py"))
+hlf = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hlf)
+
+
+def test_store_and_forward(monkeypatch, tmp_path):
+    monkeypatch.setattr(hlf, "BACKLOG_DIR", tmp_path)
+    monkeypatch.setattr(hlf, "_schedule_retry", lambda device_id: None)
+
+    def failing(*args):
+        raise RuntimeError("down")
+
+    monkeypatch.setattr(hlf, "_record_sensor_data_direct", failing)
+
+    hlf.record_sensor_data("dev1", 1, 0, 0, 0, 0, 0, 0, "t", {})
+    hlf.DEVICE_QUEUES["dev1"].join()
+
+    stats = hlf.get_backlog_stats()
+    assert stats == {"dev1": 1}
+
+    sent = []
+
+    def succeed(*args):
+        sent.append(args[1])
+
+    monkeypatch.setattr(hlf, "_record_sensor_data_direct", succeed)
+    hlf._flush_backlog("dev1")
+
+    assert sent == [1]
+    assert hlf.get_backlog_stats() == {}


### PR DESCRIPTION
## Summary
- Queue sensor writes per-device at the gateway to avoid concurrent endorsement conflicts
- Buffer failed writes on disk with exponential backoff and expiry and expose backlog stats
- Add tests for serialization and store-and-forward behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a197b63cbc8320b4cb73944abd5ee9