### PR TITLE
Secure sensor gateway with metrics

### DIFF
--- a/chaincode/sensor/sensor.go
+++ b/chaincode/sensor/sensor.go
@@ -21,6 +21,7 @@ type SensorData struct {
 	WaterLevel   float64 `json:"water_level"`
 	Timestamp    string  `json:"timestamp"`
 	Payload      string  `json:"payload"`
+	Writer       string  `json:"writer"`
 }
 
 type Device struct {
@@ -79,6 +80,10 @@ func (s *SmartContract) deviceExists(ctx contractapi.TransactionContextInterface
 }
 
 func (s *SmartContract) RecordSensorData(ctx contractapi.TransactionContextInterface, id string, seq int, temperature float64, humidity float64, soilMoisture float64, ph float64, light float64, waterLevel float64, timestamp string, payload string) error {
+	writer, err := ctx.GetClientIdentity().GetMSPID()
+	if err != nil {
+		return err
+	}
 	exists, err := s.deviceExists(ctx, id)
 	if err != nil {
 		return err
@@ -108,6 +113,7 @@ func (s *SmartContract) RecordSensorData(ctx contractapi.TransactionContextInter
 			WaterLevel:   waterLevel,
 			Timestamp:    timestamp,
 			Payload:      payload,
+			Writer:       writer,
 		}
 		incomingBytes, err := json.Marshal(incoming)
 		if err != nil {
@@ -145,6 +151,7 @@ func (s *SmartContract) RecordSensorData(ctx contractapi.TransactionContextInter
 		WaterLevel:   waterLevel,
 		Timestamp:    timestamp,
 		Payload:      payload,
+		Writer:       writer,
 	}
 	bytes, err := json.Marshal(data)
 	if err != nil {

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask==3.1.1
 numpy==2.3.2
 pytest==8.4.1
 requests==2.32.4
+prometheus-client==0.21.0


### PR DESCRIPTION
## Summary
- sign simulator payloads and support mutual TLS when configured
- verify HMAC signatures and client certs at the gateway before forwarding to Fabric
- record writer MSP ID in sensor chaincode and expose Prometheus metrics and structured logs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1a169b4188320851b736e960f28a8