### PR TITLE
docs: describe operational workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 This directory contains a minimal example of integrating Hyperledger Fabric with LoRa sensor nodes. The Fabric chaincode stores device registrations, sensor readings and network events.
 
+## Operational Workflow
+
+To perform an automatic end-to-end smoke test, run `./one_click_test.sh` or
+press **Run One-Click Demo** on the simulator page. The workflow starts the
+network, bootstraps a peer, emits sample readings and prints ledger information.
+Operators can also exercise the full system manually by following these steps:
+
+1. **Enroll the peer identity.** Run `python identity_enrollment.py` on a new node to obtain MSP materials from the certificate authority.
+2. **Retrieve the channel block.** Use `python channel_block_retrieval.py` to download the latest `mychannel` genesis block from an existing peer.
+3. **Join and synchronize.** Execute `python peer_join_sync.py` to join the channel and catch up on ledger data. When the script finishes the peer is ready to service queries and endorsements.
+4. **Register simulator devices.** Launch `python sensor_simulator.py` and follow the prompts to register devices against the Flask API and start submitting mock readings.
+5. **Verify stored data.** Inspect blocks with `python tools/block_inspector.py --info` or visit `/history` and `/integrity` on the dashboard to confirm readings were committed.
+6. **Interpret metrics.** Pages such as `/explorer`, `/storage` and `/status` expose block events, ledger size and incident counts to help validate test results.
+
+Troubleshooting tips and a more detailed walk‑through are available in the operational playbook (`start.md`).
+
 ## Chaincode
 
 `chaincode/sensor/sensor.go` implements a Fabric chaincode that allows:

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -962,6 +962,18 @@ def simulation_state():
     return jsonify({"mapping": mapping})
 
 
+@app.route("/one-click-test", methods=["POST"])
+def one_click_test_route():
+    """Launch the full demo script that boots the network and sends sample data."""
+    root = Path(__file__).resolve().parent.parent
+    script = root / "one_click_test.sh"
+    try:
+        subprocess.Popen(["bash", str(script)])
+        return jsonify({"status": "started"})
+    except Exception as exc:
+        return jsonify({"status": "error", "error": str(exc)}), 500
+
+
 @app.route("/tde")
 def tde_page():
     """Show threat detection incidents."""

--- a/one_click_test.sh
+++ b/one_click_test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Run a full end-to-end demo: start Fabric, bootstrap peer, send sample data and inspect ledger.
+
+set -Eeuo pipefail
+
+REPO_ROOT="$(realpath "$(dirname "$0")")"
+cd "$REPO_ROOT"
+
+# 1. Start the local Fabric network and deploy chaincode
+./test_network.sh
+
+# 2. Bootstrap the default peer using provided config
+if [[ -f bootstrap_config.json ]]; then
+  python node_bootstrap.py --config bootstrap_config.json || true
+fi
+
+# 3. Emit a few simulated readings (certificate verification disabled for demo)
+TMP_CFG=$(mktemp)
+cat >"$TMP_CFG" <<'JSON'
+{
+  "nodes": [
+    {"id": "demo-node", "sensors": ["dht22", "light", "ph", "soil", "water"]}
+  ]
+}
+JSON
+SIMULATOR_CONFIG="$TMP_CFG" SIMULATOR_VERIFY=false timeout 10 python sensor_simulator.py || true
+
+# 4. Display block height and ledger information
+python tools/block_inspector.py --info || true
+
+echo "Dashboard available at https://127.0.0.1:8443/"

--- a/sensor_simulator.html
+++ b/sensor_simulator.html
@@ -22,8 +22,10 @@
     <h1 class="mb-3">Test Sensor Simulator</h1>
     <p class="mb-3">Configure virtual nodes and generate synthetic readings to test the system.</p>
     <button class="btn btn-primary" onclick="startSim()">Start Simulation</button>
+    <button class="btn btn-secondary ms-2" onclick="runDemo()">Run One-Click Demo</button>
     <ul id="endpoints" class="mt-3"></ul>
     <pre id="mapping" class="bg-white border mt-3 p-3"></pre>
+    <pre id="demo-status" class="bg-white border mt-3 p-3"></pre>
   </div>
   <script>
   async function startSim(){
@@ -46,6 +48,17 @@
     const data = await res.json();
     document.getElementById('mapping').textContent = JSON.stringify(data.mapping, null, 2);
     displayEndpoints(data.mapping);
+  }
+
+  async function runDemo(){
+    const res = await fetch('/one-click-test', {method:'POST'});
+    const data = await res.json();
+    const box = document.getElementById('demo-status');
+    if(data.status === 'started'){
+      box.textContent = 'Demo started';
+    }else{
+      box.textContent = 'Error: ' + (data.error || 'unable to start');
+    }
   }
   async function loadMapping(){
     const res = await fetch('/simulation-state');

--- a/start.md
+++ b/start.md
@@ -2,6 +2,17 @@
 
 Follow these steps to set up the Hyperledger Farm Network on a new Linux node using a Python virtual environment.
 
+## Quick one-click demo
+
+To exercise the full workflow automatically, run:
+
+```bash
+./one_click_test.sh
+```
+
+Or open the simulator dashboard and click **Run One-Click Demo**.
+The script launches Fabric, bootstraps a peer, sends a few simulated readings and prints ledger info. Use the manual steps below for a step-by-step walk-through.
+
 ## 1. Clone the repository
 ```bash
 git clone https://github.com/<your-user>/hyperledger-farm-network.git
@@ -15,9 +26,9 @@ source venv/bin/activate
 ```
 
 ## 3. Install Python dependencies
-Install the packages needed by the dashboard and simulator:
+Install all required packages:
 ```bash
-pip install flask cryptography
+pip install -r requirements.txt
 ```
 
 ## 4. Start the local Fabric network
@@ -47,3 +58,43 @@ python sensor_simulator.py
 The script prompts for the number of nodes and sensors, then continuously emits sample data.
 
 You can now explore the dashboard and verify that sensor updates appear in real time. Once you are comfortable on Linux, repeat the steps on a Raspberry Pi to deploy the system to hardware.
+
+## 7. Onboard additional peers
+
+Bring a fresh node into the network by executing the bootstrap scripts in sequence:
+
+1. `python identity_enrollment.py` – enroll the node with the certificate authority and write its MSP materials.
+2. `python channel_block_retrieval.py` – fetch the latest `mychannel` block from an existing peer.
+3. `python peer_join_sync.py` – join the channel and download the current ledger state. When the script exits the peer is synchronized and ready.
+
+## 8. Register simulator devices
+
+Run `python sensor_simulator.py` again and supply a device count. The simulator calls the Flask API at `/register` to create device entries and then posts periodic sensor readings to `/sensor`.
+
+## 9. Verify data on the ledger
+
+Use the helper tools to confirm that readings were committed:
+
+```bash
+python tools/block_inspector.py --info
+python tools/block_inspector.py --block 2  # show a specific block
+peer channel getinfo -c mychannel         # query height via the Fabric CLI
+```
+
+The dashboard also exposes `/history` and `/integrity` pages for browsing and exporting stored data.
+
+## 10. Interpret metrics
+
+The web UI provides additional insight during tests:
+
+- `/explorer` – recent block activity
+- `/storage` – ledger growth
+- `/status` – device and incident counts
+
+Scripts such as `network_monitor.py` print detected LoRa nodes, while `bootstrap_status.html` summarizes the onboarding state of each peer.
+
+## Troubleshooting
+
+- **Certificate errors** – ensure the simulator trusts the self-signed certificate (`SIMULATOR_CERT`) or disable verification with `SIMULATOR_VERIFY=false`.
+- **Channel join failures** – confirm the peer can reach the orderer and that the fetched channel block matches the target channel.
+- **No data appearing** – check the Flask server logs and that the simulator is pointing at the correct URL.


### PR DESCRIPTION
## Summary
- outline end-to-end operational workflow for onboarding peers, device simulation, ledger verification and metrics
- expand ops playbook with peer bootstrap sequence, verification steps, metrics overview and troubleshooting tips
- add `one_click_test.sh` for an automatic demo and document its usage
- trigger the one-click demo from the simulator UI via a new `/one-click-test` route

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1a5e4fef08320b916104e6215a4c7