### PR TITLE
feat: add esp32 smart hub for sensor reporting

### DIFF
--- a/mermaid diagram/figure1_three_tier_system_architecture.md
+++ b/mermaid diagram/figure1_three_tier_system_architecture.md
@@ -14,24 +14,24 @@ graph TD
   %% ===== SENSING LAYER =====
   subgraph SNS[Sensing Layer]
     direction TB
-    Z1["Zone 1 (1 km²)"] --> |LoRa| GW
-    Z2["Zone 2 (1 km²)"] --> |LoRa| GW
-    ZN["Zone N"] --> |LoRa| GW
 
-    subgraph Z1[ ]
-      SM1[Soil Moisture] --> RP1[RPi 4B + LoRa]
-      T1[Temperature] --> RP1
-      NPK1[NPK Sensor] --> RP1
+    subgraph Z1["Zone 1 (1 km²)"]
+      SM1[Soil Moisture] --> ESP1[ESP32 Node]
+      T1[Temperature] --> ESP1
+      NPK1[NPK Sensor] --> ESP1
+      ESP1 --> |LoRa| GW
       style Z1 fill:#e6f7ff,stroke:#91d5ff
     end
 
-    subgraph Z2[ ]
-      SM2[Soil Moisture] --> RP2[RPi 4B + LoRa]
-      T2[Temperature] --> RP2
-      NPK2[NPK Sensor] --> RP2
+    subgraph Z2["Zone 2 (1 km²)"]
+      SM2[Soil Moisture] --> ESP2[ESP32 Node]
+      T2[Temperature] --> ESP2
+      NPK2[NPK Sensor] --> ESP2
+      ESP2 --> |LoRa| GW
       style Z2 fill:#e6f7ff,stroke:#91d5ff
     end
 
+    ZN[Zone N] --> |LoRa| GW
     style SNS fill:#f0f9e8,stroke:#43a2ca
   end
 
@@ -98,8 +98,9 @@ graph TD
 
   ANNOT2[["Hyperledger Fabric:
   - PBFT Consensus
-  - 5-sec Block Time
-  - 225 KB/day Storage"]] --> VAL
+  - 30–120 min Blocks
+  - Event-triggered writing
+  - Reduced Storage"]] --> VAL
 
   ANNOT3[["Power Metrics:
   - 10W per Node
@@ -125,9 +126,9 @@ graph TD
 - **Soil Moisture Sensor**: Capacitive V1.2 (±3% accuracy)
 - **Temperature Sensor**: DS18B20 (±0.5°C accuracy)
 - **NPK Sensor**: JXCT-IoT (N/P/K detection)
-- **Raspberry Pi 4B**: 1.5GHz quad-core, 4GB RAM
-- **LoRa Module**: SX1278 (20dBm output)
-- *Sampling Rate*: 10-second intervals
+- **ESP32**: dual-core 240 MHz, 520 KB RAM
+- **LoRa Module**: SX1278 (20 dBm output)
+- *Reporting Modes*: periodic 30–120 min updates or instant alerts on threshold breaches
 
 #### 3. Edge Processing Layer
 - **Feature Extractor**:

--- a/mermaid diagram/figure2_hyperledger_network_topology.md
+++ b/mermaid diagram/figure2_hyperledger_network_topology.md
@@ -66,9 +66,9 @@ graph LR
   - AES-128 LoRa Payloads
   - TLS 1.3 gRPC"]]:::annot --> VAL
   ANNOT2[["Performance:
-  - 5-sec Block Time
-  - 42 ms Tx Latency
-  - 225 KB/day Storage"]]:::annot --> ARC
+  - 30–120 min Blocks
+  - Event-triggered
+  - Reduced Storage"]]:::annot --> ARC
   ANNOT3[["Ledger Replication:
   - Full Copy: Validator
   - Partial: Gateway (7 days)
@@ -128,7 +128,7 @@ func (v *Validator) runPBFT() {
 ```
 
 **Block Creation**:
-- **Block Size**: 50 transactions or 5-second timeout
+- **Block Size**: 50 transactions or 30–120 minute timeout (configurable)
 - **Endorsement Policy**: `AND(Org1.Peer, Org2.Peer)`
 
 ---

--- a/tests/test_block_policy.py
+++ b/tests/test_block_policy.py
@@ -1,0 +1,42 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_client(monkeypatch, env=None):
+    if env:
+        for k, v in env.items():
+            monkeypatch.setenv(k, str(v))
+    spec = importlib.util.spec_from_file_location("hlf_client", Path("flask_app/hlf_client.py"))
+    hlf = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(hlf)
+    return hlf
+
+
+def test_time_interval_block_creation(monkeypatch):
+    hlf = load_client(monkeypatch, {"BLOCK_INTERVAL_MINUTES": 30})
+    now = 1000
+    monkeypatch.setattr(hlf.time, "time", lambda: now)
+    assert hlf._should_create_block("s1", 50, 7, 50) is True
+    now += 60
+    monkeypatch.setattr(hlf.time, "time", lambda: now)
+    assert hlf._should_create_block("s1", 50, 7, 50) is False
+    now += 30 * 60
+    monkeypatch.setattr(hlf.time, "time", lambda: now)
+    assert hlf._should_create_block("s1", 50, 7, 50) is True
+
+
+def test_event_trigger_block_creation(monkeypatch):
+    hlf = load_client(monkeypatch, {"BLOCK_INTERVAL_MINUTES": 120})
+    start = 2000
+    monkeypatch.setattr(hlf.time, "time", lambda: start)
+    # initial reading creates block and sets baseline
+    hlf._should_create_block("s1", 50, 7, 50)
+    hlf.LAST_BLOCK_TIME = start
+    # Soil moisture trigger
+    monkeypatch.setattr(hlf.time, "time", lambda: start + 10)
+    assert hlf._should_create_block("s1", hlf.SOIL_MOISTURE_THRESHOLD - 1, 7, 50)
+    hlf.LAST_BLOCK_TIME = start + 10
+    # pH change trigger
+    monkeypatch.setattr(hlf.time, "time", lambda: start + 20)
+    baseline = hlf.LAST_PH["s1"]
+    assert hlf._should_create_block("s1", 50, baseline + hlf.PH_CHANGE_THRESHOLD + 0.1, 50)

--- a/tests/test_sensor_node_reporting.py
+++ b/tests/test_sensor_node_reporting.py
@@ -1,0 +1,20 @@
+import time
+
+from sensor_node import should_transmit, SOIL_MOISTURE_THRESHOLD, PH_LOW, PH_HIGH, WATER_LEVEL_THRESHOLD
+
+
+def test_event_triggered():
+    now = time.time()
+    assert should_transmit(now, now, 60, SOIL_MOISTURE_THRESHOLD - 1, 6.0, 50.0)
+
+
+def test_periodic_report():
+    last = 0
+    now = 60 * 31  # 31 minutes
+    assert should_transmit(last, now, 30, 100.0, 6.5, 50.0)
+
+
+def test_no_trigger():
+    last = 0
+    now = 60 * 10  # 10 minutes
+    assert not should_transmit(last, now, 30, 100.0, 6.5, 50.0)


### PR DESCRIPTION
## Summary
- promote ESP32 boards to smart sensor hubs that apply thresholds and only send reports periodically or on anomalies
- document and diagram hierarchical sensor-to-gateway flow with event-triggered transmissions
- add tests for periodic vs event-driven sensor reporting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a236284c04832094b92d1155857390