### PR TITLE
feat: add scheduled and event block modes

### DIFF
--- a/tests/test_block_creation_modes.py
+++ b/tests/test_block_creation_modes.py
@@ -1,0 +1,25 @@
+import flask_app.hlf_client as hlf
+
+
+def test_scheduled_and_event_blocks(monkeypatch):
+    hlf.CURRENT_BLOCK = 0
+    hlf.BLOCK_EVENTS.clear()
+    hlf.SENSOR_DATA.clear()
+    hlf.LAST_SEQ.clear()
+    hlf.LAST_PH.clear()
+    hlf.BLOCK_BUFFER.clear()
+    hlf.LAST_BLOCK_TIME = 0.0
+    monkeypatch.setattr(hlf, "BLOCK_INTERVAL_MINUTES", 1)
+
+    times = iter([1000, 1030, 1061, 1070])
+    monkeypatch.setattr(hlf.time, "time", lambda: next(times))
+
+    hlf._record_sensor_data_direct("s1", 1, 25, 40, 50, 7.0, 200, 50, 1000, {})
+    hlf._record_sensor_data_direct("s1", 2, 25, 40, 50, 7.0, 200, 50, 1030, {})
+    hlf._record_sensor_data_direct("s1", 3, 25, 40, 50, 7.0, 200, 50, 1061, {})
+    hlf._record_sensor_data_direct("s1", 4, 25, 40, 5, 7.0, 200, 50, 1070, {})
+
+    messages = [e["message"] for e in hlf.BLOCK_EVENTS if e["message"].startswith("Creating")]
+    assert messages[0].startswith("Creating scheduled block 1")
+    assert messages[1].startswith("Creating scheduled block 2")
+    assert messages[2].startswith("Creating event block 3")

--- a/tests/test_block_policy.py
+++ b/tests/test_block_policy.py
@@ -16,13 +16,13 @@ def test_time_interval_block_creation(monkeypatch):
     hlf = load_client(monkeypatch, {"BLOCK_INTERVAL_MINUTES": 30})
     now = 1000
     monkeypatch.setattr(hlf.time, "time", lambda: now)
-    assert hlf._should_create_block("s1", 50, 7, 50) is True
+    assert hlf._should_create_block("s1", 50, 7, 50) == "scheduled"
     now += 60
     monkeypatch.setattr(hlf.time, "time", lambda: now)
-    assert hlf._should_create_block("s1", 50, 7, 50) is False
+    assert hlf._should_create_block("s1", 50, 7, 50) is None
     now += 30 * 60
     monkeypatch.setattr(hlf.time, "time", lambda: now)
-    assert hlf._should_create_block("s1", 50, 7, 50) is True
+    assert hlf._should_create_block("s1", 50, 7, 50) == "scheduled"
 
 
 def test_event_trigger_block_creation(monkeypatch):
@@ -34,9 +34,17 @@ def test_event_trigger_block_creation(monkeypatch):
     hlf.LAST_BLOCK_TIME = start
     # Soil moisture trigger
     monkeypatch.setattr(hlf.time, "time", lambda: start + 10)
-    assert hlf._should_create_block("s1", hlf.SOIL_MOISTURE_THRESHOLD - 1, 7, 50)
+    assert (
+        hlf._should_create_block("s1", hlf.SOIL_MOISTURE_THRESHOLD - 1, 7, 50)
+        == "event"
+    )
     hlf.LAST_BLOCK_TIME = start + 10
     # pH change trigger
     monkeypatch.setattr(hlf.time, "time", lambda: start + 20)
     baseline = hlf.LAST_PH["s1"]
-    assert hlf._should_create_block("s1", 50, baseline + hlf.PH_CHANGE_THRESHOLD + 0.1, 50)
+    assert (
+        hlf._should_create_block(
+            "s1", 50, baseline + hlf.PH_CHANGE_THRESHOLD + 0.1, 50
+        )
+        == "event"
+    )


### PR DESCRIPTION
## Summary
- support scheduled vs. event-driven block creation
- buffer sensor readings until block commit
- test block policy and dual block modes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a264d4a8308320bc161a474c825bd9