### PR TITLE
Add sensor adapters and sampling scheduler with rolling statistics

### DIFF
--- a/devices/leaf-node/sampling.py
+++ b/devices/leaf-node/sampling.py
@@ -1,0 +1,71 @@
+"""Sampling scheduler and rolling statistics for ESP32 sensors."""
+from __future__ import annotations
+
+import time
+from typing import Dict, Any
+from statistics import mean, pstdev
+
+from telemetry.ring_buffer import RingBuffer
+
+
+class RollingStats:
+    """Maintain a rolling window of numeric samples and compute statistics."""
+
+    def __init__(self, capacity: int = 180) -> None:
+        self.buffer = RingBuffer(capacity)
+
+    def add(self, value: float) -> None:
+        self.buffer.append(value)
+
+    def compute(self) -> Dict[str, Any]:
+        data = self.buffer.data()
+        if not data:
+            return {"min": None, "avg": None, "max": None, "std": None, "count": 0}
+        return {
+            "min": min(data),
+            "avg": mean(data),
+            "max": max(data),
+            "std": pstdev(data) if len(data) > 1 else 0.0,
+            "count": len(data),
+        }
+
+    def reset(self) -> None:
+        self.buffer = RingBuffer(self.buffer.capacity)
+
+
+class SampleScheduler:
+    """Schedule periodic sampling of sensors.
+
+    ``sensors`` maps sensor IDs to sensor instances.  ``periods`` is the sampling
+    period for each sensor in minutes (clamped to 1–5).  Readings are validated
+    via the sensor adapters and pushed into per-sensor rolling statistics.
+    """
+
+    def __init__(self, sensors: Dict[str, Any], periods: Dict[str, int]) -> None:
+        self.sensors = sensors
+        self.periods = {sid: max(1, min(5, p)) * 60 for sid, p in periods.items()}
+        # ``next_times`` defaults to ``0`` so the first ``tick`` call always
+        # performs a reading regardless of the wall-clock time passed in tests.
+        self.next_times = {sid: 0.0 for sid in sensors}
+        self.stats = {sid: RollingStats() for sid in sensors}
+
+    def tick(self, now: float | None = None) -> None:
+        now = now if now is not None else time.time()
+        for sid, sensor in self.sensors.items():
+            if now >= self.next_times[sid]:
+                try:
+                    reading = sensor.read()
+                except ValueError:
+                    # Invalid reading; schedule next attempt but do not record.
+                    self.next_times[sid] = now + self.periods[sid]
+                    continue
+                self.stats[sid].add(reading["value"])
+                self.next_times[sid] = now + self.periods[sid]
+
+    def get_stats(self) -> Dict[str, Dict[str, Any]]:
+        return {sid: rs.compute() for sid, rs in self.stats.items()}
+
+    def reset_stats(self) -> None:
+        for rs in self.stats.values():
+            rs.reset()
+

--- a/devices/leaf-node/sensors.py
+++ b/devices/leaf-node/sensors.py
@@ -1,0 +1,173 @@
+"""Sensor adapter classes for ESP32 leaf node.
+
+Each sensor exposes a common ``read`` interface returning a dictionary with
+``value``, ``ts`` (epoch seconds) and ``quality`` fields.  The concrete sensor
+classes wrap callables that perform the actual hardware interaction so that
+unit tests can inject deterministic readers.  Basic calibration hooks
+(offset, scale and optional temperature compensation) and range validation are
+provided.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional, Tuple, Dict, Any
+import time
+import random
+
+
+ReadFn = Callable[[], float]
+
+
+@dataclass
+class Calibration:
+    """Simple calibration parameters for a sensor."""
+
+    offset: float = 0.0
+    scale: float = 1.0
+    # Temperature compensation factor or function.  When a float is supplied the
+    # raw value is adjusted by ``factor * ambient_temp``.  When a callable is
+    # provided it receives ``(value, ambient_temp)`` and should return the
+    # compensated value.
+    temp_comp: Optional[Callable[[float, float], float]] | float = None
+
+
+class Sensor:
+    """Base sensor implementing the common read interface."""
+
+    def __init__(
+        self,
+        reader: ReadFn,
+        *,
+        calibration: Optional[Calibration] = None,
+        min_value: Optional[float] = None,
+        max_value: Optional[float] = None,
+    ) -> None:
+        self.reader = reader
+        self.calibration = calibration or Calibration()
+        self.min_value = min_value
+        self.max_value = max_value
+
+    # ------------------------------------------------------------------
+    def _apply_calibration(self, value: float, ambient_temp: Optional[float]) -> float:
+        value = (value + self.calibration.offset) * self.calibration.scale
+        if self.calibration.temp_comp is not None and ambient_temp is not None:
+            tc = self.calibration.temp_comp
+            if callable(tc):
+                value = tc(value, ambient_temp)
+            else:
+                value = value + tc * ambient_temp
+        return value
+
+    # ------------------------------------------------------------------
+    def read(self, ambient_temp: Optional[float] = None) -> Dict[str, Any]:
+        """Return a calibrated sensor reading.
+
+        ``ambient_temp`` may be supplied for sensors requiring temperature
+        compensation (e.g. humidity).  Out-of-range values raise ``ValueError``.
+        """
+
+        raw = self.reader()
+        value = self._apply_calibration(raw, ambient_temp)
+        if (self.min_value is not None and value < self.min_value) or (
+            self.max_value is not None and value > self.max_value
+        ):
+            raise ValueError("sensor reading out of range")
+        return {"value": value, "ts": time.time(), "quality": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# Concrete sensor implementations
+
+class DHT22Sensor(Sensor):
+    """Adapter for DHT22 providing temperature or humidity readings."""
+
+    def __init__(
+        self,
+        metric: str = "temperature",
+        reader: Optional[Callable[[], Tuple[float, float]]] = None,
+        *,
+        calibration: Optional[Calibration] = None,
+        temp_comp: Optional[Callable[[float, float], float] | float] = None,
+        min_value: Optional[float] = None,
+        max_value: Optional[float] = None,
+    ) -> None:
+        self.metric = metric
+        reader = reader or (lambda: (random.uniform(20, 30), random.uniform(40, 70)))
+        super().__init__(
+            lambda: self._select(reader()),
+            calibration=calibration or Calibration(temp_comp=temp_comp),
+            min_value=min_value,
+            max_value=max_value,
+        )
+
+    def _select(self, pair: Tuple[float, float]) -> float:
+        temp, hum = pair
+        return temp if self.metric == "temperature" else hum
+
+
+class LightSensor(Sensor):
+    def __init__(
+        self,
+        reader: Optional[ReadFn] = None,
+        *,
+        calibration: Optional[Calibration] = None,
+        min_value: Optional[float] = 0.0,
+        max_value: Optional[float] = 1023.0,
+    ) -> None:
+        reader = reader or (lambda: random.uniform(0.0, 1023.0))
+        super().__init__(
+            reader,
+            calibration=calibration,
+            min_value=min_value,
+            max_value=max_value,
+        )
+
+
+class SoilMoistureSensor(Sensor):
+    def __init__(
+        self,
+        reader: Optional[ReadFn] = None,
+        *,
+        calibration: Optional[Calibration] = None,
+        min_value: Optional[float] = 0.0,
+        max_value: Optional[float] = 100.0,
+    ) -> None:
+        reader = reader or (lambda: random.uniform(0.0, 100.0))
+        super().__init__(reader, calibration=calibration, min_value=min_value, max_value=max_value)
+
+
+class PHSensor(Sensor):
+    def __init__(
+        self,
+        reader: Optional[ReadFn] = None,
+        *,
+        calibration: Optional[Calibration] = None,
+        min_value: Optional[float] = 0.0,
+        max_value: Optional[float] = 14.0,
+    ) -> None:
+        reader = reader or (lambda: random.uniform(0.0, 14.0))
+        super().__init__(reader, calibration=calibration, min_value=min_value, max_value=max_value)
+
+
+class WaterLevelSensor(Sensor):
+    def __init__(
+        self,
+        reader: Optional[ReadFn] = None,
+        *,
+        calibration: Optional[Calibration] = None,
+        min_value: Optional[float] = 0.0,
+        max_value: Optional[float] = 100.0,
+    ) -> None:
+        reader = reader or (lambda: random.uniform(0.0, 100.0))
+        super().__init__(reader, calibration=calibration, min_value=min_value, max_value=max_value)
+
+
+__all__ = [
+    "Calibration",
+    "Sensor",
+    "DHT22Sensor",
+    "LightSensor",
+    "SoilMoistureSensor",
+    "PHSensor",
+    "WaterLevelSensor",
+]

--- a/devices/leaf-node/tests/test_sampling_loop.py
+++ b/devices/leaf-node/tests/test_sampling_loop.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from sensors import LightSensor, Calibration
+from sampling import SampleScheduler
+
+
+def test_sensor_read_and_calibration():
+    sensor = LightSensor(reader=lambda: 10.0, calibration=Calibration(offset=1.0, scale=2.0))
+    reading = sensor.read()
+    assert reading["value"] == 22.0
+    assert "ts" in reading and "quality" in reading
+
+
+def test_scheduler_sampling_and_stats():
+    values = iter([10.0, 20.0, -5.0, 30.0, 40.0])
+    sensor = LightSensor(reader=lambda: next(values), min_value=0.0, max_value=100.0)
+    sched = SampleScheduler({"light": sensor}, {"light": 1})
+
+    now = 0.0
+    for _ in range(5):
+        sched.tick(now)
+        now += 60.0  # advance 1 minute
+
+    stats = sched.get_stats()["light"]
+    assert stats["count"] == 4  # one invalid reading skipped
+    assert stats["min"] == 10.0
+    assert stats["max"] == 40.0
+    assert abs(stats["avg"] - (10 + 20 + 30 + 40) / 4) < 1e-6
+    assert len(sched.stats["light"].buffer) == 4
+
+    sched.reset_stats()
+    assert sched.get_stats()["light"]["count"] == 0


### PR DESCRIPTION
## Summary
- Implement sensor adapter classes with common `read` interface and calibration hooks
- Introduce sampling scheduler with per-sensor rolling statistics and range validation
- Add unit tests covering calibration, sampling, and stat reset behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a26b2633a88320b40ee0f809ff10ff