### PR TITLE
feat: add windowed telemetry persistence

### DIFF
--- a/devices/leaf-node/docs/payload.md
+++ b/devices/leaf-node/docs/payload.md
@@ -7,7 +7,7 @@ following JSON structure:
 {
   "device_id": "<string>",
   "seq": <integer>,
-  "window_id": <integer>,
+  "window_id": [<start_ts>, <end_ts>],
   "stats": {
     "min": <number>,
     "avg": <number>,
@@ -16,6 +16,7 @@ following JSON structure:
     "count": <integer>
   },
   "last_ts": <integer>,
+  "tail": [<number>, ...],
   "sensor_set": ["<sensor id>", ...],
   "urgent": <boolean>,
   "crt": {
@@ -28,9 +29,11 @@ following JSON structure:
 
 * `device_id` – unique identifier for the ESP32 leaf node.
 * `seq` – monotonically increasing sequence number used for deduplication.
-* `window_id` – identifier for the aggregation window.
+* `window_id` – `[start_ts, end_ts]` pair identifying the aggregation window
+  aligned to the configured uplink period.
 * `stats` – windowed statistics for the sensor readings.
 * `last_ts` – epoch timestamp of the most recent sample in the window.
+* `tail` – optional raw tail of recent readings for diagnostics.
 * `sensor_set` – list of sensors included in the payload.
 * `urgent` – signals that the payload contains threshold breaches and should
   be processed immediately.

--- a/devices/leaf-node/telemetry/__init__.py
+++ b/devices/leaf-node/telemetry/__init__.py
@@ -1,0 +1,13 @@
+"""Telemetry utilities for ESP32 leaf nodes."""
+
+from .ring_buffer import RingBuffer
+from .seq_store import SeqStore
+from .summary_store import SummaryStore
+from .window import WindowBatcher
+
+__all__ = [
+    "RingBuffer",
+    "SeqStore",
+    "SummaryStore",
+    "WindowBatcher",
+]

--- a/devices/leaf-node/telemetry/summary_store.py
+++ b/devices/leaf-node/telemetry/summary_store.py
@@ -1,0 +1,87 @@
+"""Persistent summary queue with monotonic sequence numbers."""
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+
+class SummaryStore:
+    """File-backed FIFO store for window summaries.
+
+    The store keeps pending summaries along with a monotonically increasing
+    sequence number.  Both the queue and the sequence counter are persisted in
+    the same file so that they survive reboots without introducing duplicate
+    sequence values.
+    """
+
+    def __init__(self, path: str = "summaries.json", *, expiry_sec: int = 24 * 3600) -> None:
+        self.path = path
+        self.expiry_sec = expiry_sec
+        self.last_seq = 0
+        self.queue: List[Dict[str, Any]] = []
+        self._load()
+
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        try:
+            with open(self.path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.last_seq = int(data.get("last_seq", 0))
+            self.queue = list(data.get("queue", []))
+        except Exception:
+            self.last_seq = 0
+            self.queue = []
+        self._purge_expired(persist=False)
+
+    # ------------------------------------------------------------------
+    def _persist(self) -> None:
+        tmp = f"{self.path}.tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump({"last_seq": self.last_seq, "queue": self.queue}, f)
+        os.replace(tmp, self.path)
+
+    # ------------------------------------------------------------------
+    def _purge_expired(self, *, persist: bool = True) -> None:
+        now = time.time()
+        new_queue = [
+            item
+            for item in self.queue
+            if now - item.get("window_id", [0, 0])[1] <= self.expiry_sec
+        ]
+        if len(new_queue) != len(self.queue):
+            self.queue = new_queue
+            if persist:
+                self._persist()
+
+    # ------------------------------------------------------------------
+    def enqueue(self, summary: Dict[str, Any]) -> int:
+        """Append ``summary`` assigning the next sequence value."""
+        self.last_seq += 1
+        item = dict(summary)
+        item["seq"] = self.last_seq
+        self.queue.append(item)
+        self._persist()
+        return self.last_seq
+
+    # ------------------------------------------------------------------
+    def peek(self) -> Optional[Dict[str, Any]]:
+        """Return the next summary without removing it."""
+        self._purge_expired()
+        return self.queue[0] if self.queue else None
+
+    # ------------------------------------------------------------------
+    def dequeue(self) -> Optional[Dict[str, Any]]:
+        """Remove and return the next summary."""
+        self._purge_expired()
+        if not self.queue:
+            return None
+        item = self.queue.pop(0)
+        self._persist()
+        return item
+
+    # ------------------------------------------------------------------
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.queue)
+

--- a/devices/leaf-node/telemetry/window.py
+++ b/devices/leaf-node/telemetry/window.py
@@ -1,0 +1,134 @@
+"""Windowed batching and summarisation for sensor readings."""
+from __future__ import annotations
+
+import json
+import math
+import os
+import statistics
+from typing import Any, Dict, List
+
+from .summary_store import SummaryStore
+from .ring_buffer import RingBuffer
+
+
+class WindowBatcher:
+    """Aggregate sensor samples into fixed windows.
+
+    ``period_sec`` defines the duration of each window.  Samples added via
+    :meth:`add_sample` are buffered until their timestamp crosses the window
+    boundary, at which point a summary record is created and persisted to the
+    provided :class:`SummaryStore`.
+    """
+
+    def __init__(
+        self,
+        period_sec: int,
+        store: SummaryStore,
+        *,
+        tail_size: int = 5,
+        state_path: str = "window_state.json",
+    ) -> None:
+        self.period = period_sec
+        self.store = store
+        self.tail_size = tail_size
+        self.state_path = state_path
+
+        self.samples: List[Dict[str, Any]] = []
+        self.tail = RingBuffer(tail_size)
+        self.start_ts: int | None = None
+        self.end_ts: int | None = None
+        self.last_sample: Dict[str, Any] | None = None
+        self._load_state()
+
+    # ------------------------------------------------------------------
+    def _align_start(self, ts: float) -> int:
+        return int(math.floor(ts / self.period) * self.period)
+
+    # ------------------------------------------------------------------
+    def _load_state(self) -> None:
+        try:
+            with open(self.state_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.samples = data.get("samples", [])
+            self.start_ts = data.get("start_ts")
+            self.end_ts = data.get("end_ts")
+            self.last_sample = data.get("last_sample")
+            self.tail = RingBuffer(self.tail_size)
+            for s in data.get("tail", []):
+                self.tail.append(s)
+        except Exception:
+            # Fresh state
+            self.samples = []
+            self.start_ts = None
+            self.end_ts = None
+            self.last_sample = None
+            self.tail = RingBuffer(self.tail_size)
+
+    # ------------------------------------------------------------------
+    def _persist_state(self) -> None:
+        tmp = f"{self.state_path}.tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "samples": self.samples,
+                    "start_ts": self.start_ts,
+                    "end_ts": self.end_ts,
+                    "last_sample": self.last_sample,
+                    "tail": list(self.tail),
+                },
+                f,
+            )
+        os.replace(tmp, self.state_path)
+
+    # ------------------------------------------------------------------
+    def add_sample(self, reading: Dict[str, Any]) -> None:
+        ts = reading["ts"]
+        if self.start_ts is None:
+            self.start_ts = self._align_start(ts)
+            self.end_ts = self.start_ts + self.period
+        if ts >= self.end_ts:
+            if self.samples:
+                self._finalise_window(self.last_sample)
+            self.start_ts = self._align_start(ts)
+            self.end_ts = self.start_ts + self.period
+            self.samples = []
+            self.tail = RingBuffer(self.tail_size)
+        self.samples.append(reading)
+        self.tail.append(reading)
+        self.last_sample = reading
+        self._persist_state()
+
+    # ------------------------------------------------------------------
+    def _finalise_window(self, last_sample: Dict[str, Any] | None) -> None:
+        if not self.samples or last_sample is None:
+            return
+        values = [s["value"] for s in self.samples]
+        stats = {
+            "min": min(values),
+            "avg": statistics.mean(values),
+            "max": max(values),
+            "std": statistics.pstdev(values) if len(values) > 1 else 0.0,
+            "count": len(values),
+        }
+        summary = {
+            "window_id": [self.start_ts, self.end_ts],
+            "stats": stats,
+            "last_sample": last_sample,
+            "last_ts": last_sample["ts"],
+            "tail": [s["value"] for s in self.tail],
+        }
+        self.store.enqueue(summary)
+
+    # ------------------------------------------------------------------
+    def flush(self) -> None:
+        """Force emission of the current window summary."""
+        if self.samples:
+            self._finalise_window(self.last_sample)
+            self.samples = []
+            self.tail = RingBuffer(self.tail_size)
+            self.start_ts = None
+            self.end_ts = None
+            self.last_sample = None
+            if os.path.exists(self.state_path):
+                os.remove(self.state_path)
+

--- a/devices/leaf-node/tests/test_window_batcher.py
+++ b/devices/leaf-node/tests/test_window_batcher.py
@@ -1,0 +1,69 @@
+import sys
+import time
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from telemetry.summary_store import SummaryStore
+from telemetry.window import WindowBatcher
+
+
+def test_window_summary_and_tail(tmp_path):
+    store_path = tmp_path / "store.json"
+    state_path = tmp_path / "state.json"
+    store = SummaryStore(str(store_path))
+    wm = WindowBatcher(60, store, tail_size=5, state_path=str(state_path))
+
+    base = time.time()
+    start = int((base + 10) // 60 * 60)
+    wm.add_sample({"ts": base + 10, "value": 1})
+    wm.add_sample({"ts": start + 30, "value": 3})
+    wm.add_sample({"ts": start + 65, "value": 5})  # closes first window
+
+    summary = store.peek()
+    assert summary["window_id"] == [start, start + 60]
+    assert summary["stats"]["min"] == 1
+    assert summary["stats"]["max"] == 3
+    assert summary["last_sample"]["value"] == 3
+    assert summary["tail"] == [1, 3]
+
+
+def test_resume_and_sequence(tmp_path):
+    store_path = tmp_path / "store.json"
+    state_path = tmp_path / "state.json"
+    store = SummaryStore(str(store_path))
+    wm = WindowBatcher(60, store, tail_size=5, state_path=str(state_path))
+
+    base = time.time()
+    start = int((base + 5) // 60 * 60)
+    wm.add_sample({"ts": base + 5, "value": 2})
+    # simulate reboot
+    wm2 = WindowBatcher(60, store, tail_size=5, state_path=str(state_path))
+    wm2.add_sample({"ts": start + 35, "value": 4})
+    wm2.add_sample({"ts": start + 65, "value": 6})  # closes first window
+    wm2.flush()
+
+    first = store.dequeue()
+    second = store.dequeue()
+    assert first["seq"] == 1
+    assert second["seq"] == 2
+    assert second["stats"]["count"] == 1  # window after reboot has one sample
+
+
+def test_store_and_forward_expiry(tmp_path):
+    store_path = tmp_path / "store.json"
+    state_path = tmp_path / "state.json"
+    store = SummaryStore(str(store_path), expiry_sec=1)
+    wm = WindowBatcher(60, store, tail_size=5, state_path=str(state_path))
+
+    base = time.time()
+    wm.add_sample({"ts": base, "value": 1})
+    wm.add_sample({"ts": base + 60, "value": 2})  # closes window
+
+    assert store.peek() is not None
+    # mark as very old
+    store.queue[0]["window_id"][1] = 0
+    store._persist()
+
+    store2 = SummaryStore(str(store_path), expiry_sec=1)
+    assert store2.peek() is None


### PR DESCRIPTION
## Summary
- implement `SummaryStore` for atomic summary + sequence persistence with expiry
- add `WindowBatcher` to emit windowed stats, last sample and raw tail
- document payload window identifiers and raw tail field

## Testing
- `pytest devices/leaf-node/tests/test_window_batcher.py -q`
- `pytest devices/leaf-node/tests -q`
- `pytest tests -q` *(fails: ModuleNotFoundError: No module named 'flask_app')*


------
https://chatgpt.com/codex/tasks/task_e_68a26ca22f64832082771d95888eca99