### PR TITLE
Add optional CRT payload compaction

### DIFF
--- a/devices/leaf-node/telemetry/__init__.py
+++ b/devices/leaf-node/telemetry/__init__.py
@@ -4,10 +4,13 @@ from .ring_buffer import RingBuffer
 from .seq_store import SeqStore
 from .summary_store import SummaryStore
 from .window import WindowBatcher
+from .payload import build_payload, crt_encoder
 
 __all__ = [
     "RingBuffer",
     "SeqStore",
     "SummaryStore",
     "WindowBatcher",
+    "build_payload",
+    "crt_encoder",
 ]

--- a/devices/leaf-node/telemetry/payload.py
+++ b/devices/leaf-node/telemetry/payload.py
@@ -1,0 +1,65 @@
+"""Payload construction with optional CRT compaction."""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable, List, Optional
+
+from crt_parallel import crt_decompose
+
+
+def crt_encoder(values: Iterable[int], moduli: Iterable[int]) -> Dict[str, List[int]]:
+    """Pack ``values`` into CRT residues using ``moduli``.
+
+    The values are concatenated in a base equal to the smallest modulus.  All
+    values must therefore be strictly smaller than that modulus for the packing
+    to be reversible.
+    """
+
+    vals = [int(v) for v in values]
+    mods = list(int(m) for m in moduli)
+    base = min(mods)
+    if any(v >= base for v in vals):
+        raise ValueError("values must be smaller than smallest modulus")
+
+    block = 0
+    for v in vals:
+        block = block * base + v
+    residues = crt_decompose(block, mods)
+    return {"m": mods, "r": residues}
+
+
+def build_payload(
+    summary: Dict[str, Any], *, moduli: Optional[List[int]] = None, size_limit: int = 100
+) -> Dict[str, Any]:
+    """Return a payload ensuring it fits within ``size_limit`` bytes.
+
+    When the JSON representation exceeds ``size_limit`` and ``moduli`` are
+    supplied, numeric stats are replaced with a compact ``crt`` field.  If the
+    payload remains too large the raw ``tail`` data is dropped.
+    """
+
+    payload: Dict[str, Any] = {
+        "window_id": summary["window_id"],
+        "stats": summary["stats"],
+        "last_ts": summary["last_ts"],
+        "tail": summary.get("tail", []),
+    }
+
+    body = json.dumps(payload, separators=(",", ":")).encode()
+    if len(body) > size_limit and moduli:
+        stats = payload.pop("stats")
+        numbers = [
+            int(round(stats["min"] * 100)),
+            int(round(stats["avg"] * 100)),
+            int(round(stats["max"] * 100)),
+            int(round(stats["std"] * 100)),
+            int(stats["count"]),
+        ]
+        payload["crt"] = crt_encoder(numbers, moduli)
+        body = json.dumps(payload, separators=(",", ":")).encode()
+    if len(body) > size_limit and "tail" in payload:
+        payload.pop("tail")
+    return payload
+
+
+__all__ = ["crt_encoder", "build_payload"]

--- a/devices/leaf-node/tests/test_payload.py
+++ b/devices/leaf-node/tests/test_payload.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+import sys
+base = Path(__file__).resolve()
+sys.path.append(str(base.parents[1]))  # leaf-node
+sys.path.append(str(base.parents[3]))  # repo root
+
+from telemetry.payload import build_payload, crt_encoder  # noqa: E402
+
+MODULI = [401, 409, 419, 421, 431]
+
+
+def test_payload_without_crt():
+    summary = {
+        "window_id": [0, 60],
+        "stats": {"min": 1.0, "avg": 2.0, "max": 3.0, "std": 0.5, "count": 5},
+        "last_ts": 1,
+        "tail": [1, 2],
+    }
+    payload = build_payload(summary, size_limit=100)
+    assert "stats" in payload
+    assert "crt" not in payload
+    body = json.dumps(payload, separators=(",", ":")).encode()
+    assert len(body) <= 100
+
+
+def test_payload_with_crt_and_tail_drop():
+    summary = {
+        "window_id": [0, 60],
+        "stats": {"min": 1.0, "avg": 2.0, "max": 3.0, "std": 0.5, "count": 5},
+        "last_ts": 1,
+        "tail": list(range(20)),
+    }
+    payload = build_payload(summary, moduli=MODULI, size_limit=100)
+    assert "crt" in payload
+    assert "stats" not in payload
+    assert "tail" not in payload
+    body = json.dumps(payload, separators=(",", ":")).encode()
+    assert len(body) <= 100

--- a/docs/crt.md
+++ b/docs/crt.md
@@ -1,0 +1,21 @@
+# CRT Encoding and Reconstruction
+
+Leaf nodes may compact several numeric values into a single integer using the
+Chinese Remainder Theorem (CRT).  The residues and their moduli are transmitted
+in the payload under the `crt` key:
+
+```json
+"crt": {"m": [65521,65519,65497,65479,65449], "r": [<int>, ...]}
+```
+
+At the Raspberry Pi gateway the original value is recovered using **Garner's
+algorithm**.  Garner's method incrementally reconstructs the unique integer `x`
+that satisfies `x ≡ r_i (mod m_i)` for all residues.  Starting with `x = 0` and
+a running product `M = 1`, each pair `(r_i, m_i)` updates the accumulator:
+
+1. Compute the partial inverse `inv = M^{-1} (mod m_i)`.
+2. Set `x = x + (r_i - x) * inv * M`.
+3. Update `M = M * m_i`.
+
+After processing all residues, `x` holds the packed integer which can then be
+unpacked into the original stats or hashes.


### PR DESCRIPTION
## Summary
- add crt_encoder to pack stats/hashes into CRT residues
- compact leaf-node payloads with optional CRT field to respect 100 byte limit
- document Pi-side reconstruction using Garner's algorithm

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a26e4f4c448320b83c9feb7f077b39