### PR TITLE
Implement secure Pi transport with signing and health endpoints

### DIFF
--- a/devices/leaf-node/telemetry/__init__.py
+++ b/devices/leaf-node/telemetry/__init__.py
@@ -5,6 +5,7 @@ from .seq_store import SeqStore
 from .summary_store import SummaryStore
 from .window import WindowBatcher
 from .event_detector import EventDetector
+from .transport import PiClient, create_debug_app
 
 try:  # Optional CRT payload support
     from .payload import build_payload, crt_encoder
@@ -19,4 +20,6 @@ __all__ = [
     "build_payload",
     "crt_encoder",
     "EventDetector",
+    "PiClient",
+    "create_debug_app",
 ]

--- a/devices/leaf-node/telemetry/transport.py
+++ b/devices/leaf-node/telemetry/transport.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+import time
+import hmac
+import hashlib
+from typing import Any, Dict, List, Optional
+
+import requests
+
+try:  # Optional Ed25519 support
+    from nacl.signing import SigningKey  # type: ignore
+except Exception:  # pragma: no cover - library may be missing
+    SigningKey = None  # type: ignore
+
+
+class PiClient:
+    """Transmit signed payloads to Raspberry Pi gateways with failover.
+
+    The client performs a nonce-based handshake with the current target Pi
+    before sending data.  Payloads are signed using HMAC by default or
+    Ed25519 when a private key is supplied.  Failures increment a counter and
+    after ``max_failures`` the client switches to the next Pi in
+    ``targets``.
+    """
+
+    def __init__(
+        self,
+        targets: List[str],
+        *,
+        hmac_key: Optional[bytes] = None,
+        ed25519_sk: Optional[bytes] = None,
+        max_failures: int = 3,
+    ) -> None:
+        if not targets:
+            raise ValueError("at least one target required")
+        self.targets = targets
+        self.session = requests.Session()
+        self.max_failures = max_failures
+        self._current = 0
+        self._failures = 0
+        self.buffer: List[Dict[str, Any]] = []
+        self.last_uplink: Optional[float] = None
+        self.seq = 0
+        self.event_count = 0
+
+        if ed25519_sk and SigningKey:
+            self._signer = SigningKey(ed25519_sk)
+            self.kid = "ed25519"
+            self._hmac_key = None
+        elif hmac_key is not None:
+            self._signer = None
+            self._hmac_key = hmac_key
+            self.kid = "hmac"
+        else:
+            raise ValueError("hmac_key or ed25519_sk required")
+
+    # ------------------------------------------------------------------
+    # Helper methods
+    def _sign(self, data: bytes) -> str:
+        if self._signer is not None:
+            return self._signer.sign(data).signature.hex()
+        assert self._hmac_key is not None
+        return hmac.new(self._hmac_key, data, hashlib.sha256).hexdigest()
+
+    def _advance_target(self) -> None:
+        if len(self.targets) > 1:
+            self._current = (self._current + 1) % len(self.targets)
+        self._failures = 0
+
+    # ------------------------------------------------------------------
+    # Handshake + transmit
+    def _handshake(self) -> bool:
+        url = self.targets[self._current]
+        try:
+            r = self.session.get(f"{url}/handshake", timeout=5)
+            r.raise_for_status()
+            nonce = r.json()["nonce"]
+            sig = self._sign(nonce.encode())
+            r2 = self.session.post(
+                f"{url}/handshake",
+                json={"nonce": nonce, "sig": sig, "kid": self.kid},
+                timeout=5,
+            )
+            r2.raise_for_status()
+            self._failures = 0
+            return True
+        except Exception:
+            self._failures += 1
+            if self._failures >= self.max_failures:
+                self._advance_target()
+            return False
+
+    def _post(self, payload: Dict[str, Any]) -> bool:
+        url = self.targets[self._current]
+        try:
+            self.session.post(f"{url}/ingest", json=payload, timeout=5)
+            self.last_uplink = time.time()
+            self._failures = 0
+            return True
+        except Exception:
+            self._failures += 1
+            if self._failures >= self.max_failures:
+                self._advance_target()
+            return False
+
+    # ------------------------------------------------------------------
+    def send(self, payload: Dict[str, Any]) -> None:
+        """Sign and transmit ``payload`` to the current Pi."""
+        self.seq += 1
+        payload["seq"] = self.seq
+        if payload.get("urgent"):
+            self.event_count += 1
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        payload["sig"] = self._sign(body)
+        payload["kid"] = self.kid
+
+        if not self._handshake() or not self._post(payload):
+            self.buffer.append(payload)
+
+    def flush(self) -> None:
+        """Attempt to send any buffered payloads."""
+        if not self.buffer:
+            return
+        queued = self.buffer[:]
+        self.buffer.clear()
+        for pkt in queued:
+            self.send(pkt)
+            if pkt in self.buffer:  # still failed, stop to avoid busy loop
+                break
+
+    # ------------------------------------------------------------------
+    def status(self) -> Dict[str, Any]:
+        """Return current health metrics."""
+        return {
+            "buffer_depth": len(self.buffer),
+            "last_uplink": self.last_uplink,
+            "seq": self.seq,
+            "event_count": self.event_count,
+        }
+
+
+# ----------------------------------------------------------------------
+# Debug web application
+
+
+def create_debug_app(client: PiClient):
+    """Return a minimal Flask app exposing ``/health`` and ``/status``."""
+    from flask import Flask, jsonify
+
+    app = Flask(__name__)
+
+    @app.route("/health")
+    def health():  # pragma: no cover - simple JSON
+        return jsonify({"status": "ok"})
+
+    @app.route("/status")
+    def status():  # pragma: no cover - simple JSON
+        return jsonify(client.status())
+
+    return app
+
+
+__all__ = ["PiClient", "create_debug_app"]

--- a/devices/leaf-node/tests/test_transport.py
+++ b/devices/leaf-node/tests/test_transport.py
@@ -1,0 +1,71 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))  # leaf-node
+
+from telemetry.transport import PiClient, create_debug_app  # noqa: E402
+
+
+class DummyResponse:
+    def __init__(self, json_data=None):
+        self._json = json_data or {}
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._json
+
+
+class DummySession:
+    def __init__(self):
+        self.handshakes = 0
+        self.posts = []
+        self.fail = False
+
+    def get(self, url, timeout=5):
+        if self.fail:
+            raise RuntimeError("down")
+        self.handshakes += 1
+        return DummyResponse({"nonce": "n"})
+
+    def post(self, url, json=None, timeout=5):
+        if self.fail:
+            raise RuntimeError("down")
+        self.posts.append((url, json))
+        return DummyResponse()
+
+
+def test_sign_and_handshake():
+    client = PiClient(["http://pi"], hmac_key=b"secret")
+    sess = DummySession()
+    client.session = sess
+    client.send({"data": 1})
+    # one GET for nonce and two POSTs (handshake + ingest)
+    assert sess.handshakes == 1
+    assert len(sess.posts) == 2
+    ingest = sess.posts[1][1]
+    assert ingest["seq"] == 1
+    assert ingest["kid"] == "hmac"
+    assert "sig" in ingest
+
+
+def test_failover_after_handshake_failure():
+    client = PiClient(["http://a", "http://b"], hmac_key=b"k", max_failures=1)
+    sess = DummySession()
+    sess.fail = True
+    client.session = sess
+    client.send({"data": 1})
+    # payload buffered and target switched to index 1
+    assert client.buffer
+    assert client._current == 1
+
+
+def test_health_status_endpoint():
+    client = PiClient(["http://pi"], hmac_key=b"k")
+    app = create_debug_app(client)
+    with app.test_client() as c:
+        assert c.get("/health").json == {"status": "ok"}
+        client.buffer.append({"x": 1})
+        data = c.get("/status").json
+        assert data["buffer_depth"] == 1


### PR DESCRIPTION
## Summary
- add `PiClient` supporting HMAC or Ed25519 signed payloads and Pi failover
- perform nonce-based handshake and expose `/health` & `/status` for debug monitoring
- cover handshake, failover and status endpoints with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a27568fb608320bdbea8f58d9fc439