### PR TITLE
feat(sensor): extend chaincode schema

### DIFF
--- a/chaincode/sensor/META-INF/statedb/couchdb/indexes/eventIndex.json
+++ b/chaincode/sensor/META-INF/statedb/couchdb/indexes/eventIndex.json
@@ -1,0 +1,8 @@
+{
+  "index": {
+    "fields": ["device_id", "ts"]
+  },
+  "ddoc": "eventDeviceTsIndex",
+  "name": "eventDeviceTsIndex",
+  "type": "json"
+}

--- a/chaincode/sensor/META-INF/statedb/couchdb/indexes/readingIndex.json
+++ b/chaincode/sensor/META-INF/statedb/couchdb/indexes/readingIndex.json
@@ -1,0 +1,8 @@
+{
+  "index": {
+    "fields": ["device_id", "window_id"]
+  },
+  "ddoc": "readingDeviceWindowIndex",
+  "name": "readingDeviceWindowIndex",
+  "type": "json"
+}


### PR DESCRIPTION
## Summary
- add reading and event key spaces with device/window/ts metadata
- enforce idempotent writes with per-device sequence tracking
- add CouchDB indexes for efficient device/window/ts lookups and emit commit events

## Testing
- `go test ./...`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2fb00680c832094647d89015c73ac