### PR TITLE
Improve gateway scheduling and orderer batching

### DIFF
--- a/docker-compose-test-net-override.yaml
+++ b/docker-compose-test-net-override.yaml
@@ -5,6 +5,9 @@ version: '3.7'
 services:
   orderer.example.com:
     restart: unless-stopped
+    environment:
+      - ORDERER_GENERAL_BATCHTIMEOUT=2s
+      - ORDERER_GENERAL_BATCHSIZE_MAXMESSAGECOUNT=200
     volumes:
       - ../organizations/ordererOrganizations/example.com/orderers/orderer.example.com/msp:/var/hyperledger/orderer/msp
       - ../organizations/ordererOrganizations/example.com/orderers/orderer.example.com/tls:/var/hyperledger/orderer/tls


### PR DESCRIPTION
## Summary
- configure test-network orderer with 2s batch timeout and 200 max messages
- gate Pi bundles by 30–120 minute intervals and flush urgent events instantly
- wait for commit events and log submit-to-commit latency in gateway

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2fe6890ec8320aaf3e29de1f7dc81