### PR TITLE
Add Flask app factory and package init files

### DIFF
--- a/flask_app/__init__.py
+++ b/flask_app/__init__.py
@@ -1,0 +1,19 @@
+"""Flask application package with a lazily-loaded factory."""
+
+from __future__ import annotations
+
+__all__ = ["create_app", "get_app"]
+
+
+def create_app(*args, **kwargs):
+    """Return a configured :class:`~flask.Flask` application instance."""
+    from .app import create_app as _create_app
+
+    return _create_app(*args, **kwargs)
+
+
+def get_app():
+    """Return the module-level Flask application."""
+    from .app import app as _app
+
+    return _app

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -90,7 +90,28 @@ HealthServer = _orch.HealthServer
 hmac_sha256 = _orch.hmac_sha256
 main = _orch.main
 
-app = Flask(__name__)
+
+def create_app(config: dict | None = None) -> Flask:
+    """Application factory for the gateway Flask service.
+
+    Parameters
+    ----------
+    config: dict | None
+        Optional configuration values to apply to the application instance.
+
+    Returns
+    -------
+    flask.Flask
+        Configured Flask application ready for registration of routes.
+    """
+
+    application = Flask(__name__)
+    if config:
+        application.config.update(config)
+    return application
+
+
+app = create_app()
 
 # Shared secret for simulator payload signatures
 HMAC_KEY = os.environ.get("HMAC_KEY", "").encode()

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Utility tooling for the Hyperledger demo."""


### PR DESCRIPTION
## Summary
- add create_app factory to flask_app for easier configuration
- add __init__ modules so flask_app and tools act as packages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a326f0db8883209e40de48f41be3bf