### PR TITLE
docs: expand to five-tier architecture

### DIFF
--- a/docs/device_registry.md
+++ b/docs/device_registry.md
@@ -1,0 +1,3 @@
+# Device Registry
+
+JSON file mapping each `device_id` to its HMAC key for payload verification. The gateway loads `devices/leaf-node/config/leaf_config.json` to build this mapping.

--- a/docs/gateway_config.md
+++ b/docs/gateway_config.md
@@ -1,0 +1,6 @@
+# Gateway Configuration Knobs
+
+* `UPLINK_PERIOD_MIN` – minutes between periodic summaries.
+* `EVENT_COALESCE_SEC` – seconds to group rapid events.
+* `EVENT_RATE_LIMIT_PER_PI` – maximum events per Pi per minute.
+* `STORE_MAX_AGE_HOURS` – hours before queued bundles expire.

--- a/flask_app/Bundler.md
+++ b/flask_app/Bundler.md
@@ -1,0 +1,3 @@
+# Bundler
+
+Collects normalized readings into IntervalBundle or EventBundle groups and forwards them to the scheduler. Implements coalescing and rate limiting policies.

--- a/flask_app/FabricClient.md
+++ b/flask_app/FabricClient.md
@@ -1,0 +1,3 @@
+# FabricClient
+
+Lightweight wrapper around Hyperledger Fabric SDK used by the gateway to submit bundles and query ledger state. Tracks last commit time for readiness checks.

--- a/flask_app/IngressService.md
+++ b/flask_app/IngressService.md
@@ -1,0 +1,3 @@
+# IngressService
+
+Validates signed leaf payloads and normalizes readings before handing them to the bundler. Acts as the first hop for sensor data arriving at the gateway.

--- a/flask_app/MeshMonitor.md
+++ b/flask_app/MeshMonitor.md
@@ -1,0 +1,3 @@
+# MeshMonitor
+
+Observes BATMAN-adv mesh status via `batctl` and exposes neighbor and ETX metrics for health checks. Helps reroute traffic when paths degrade.

--- a/flask_app/Scheduler.md
+++ b/flask_app/Scheduler.md
@@ -1,0 +1,3 @@
+# Scheduler
+
+Triggers submissions of bundled transactions on cadence for summaries and immediately for events. Coordinates retries and timing windows.

--- a/flask_app/StoreAndForward.md
+++ b/flask_app/StoreAndForward.md
@@ -1,0 +1,3 @@
+# StoreAndForward
+
+Durably queues outgoing bundles on disk and retries submission with exponential backoff. Ensures no data is lost during network outages.

--- a/mermaid diagram/figure1_three_tier_system_architecture.md
+++ b/mermaid diagram/figure1_three_tier_system_architecture.md
@@ -1,199 +1,183 @@
-# Figure 1: Three-Tier System Architecture
+# Figure 1 — Five-Tier System Architecture (ESP32 → Pi → Mesh → Fabric → Observability)
+
+This diagram shows the **complete, self-contained farm ledger** with **periodic blocks (30–120 min)** and **event-triggered blocks (immediate)**.  
+Tiers are color-separated; arrows label **what** is transmitted, **how**, and **when**.
 
 ```mermaid
-graph TD
-  %% ===== POWER LAYER =====
-  subgraph PWR[Power Layer]
+flowchart LR
+  %% ========= CLASSES / COLORS =========
+  classDef tier1 fill:#E6FFF2,stroke:#00A86B,stroke-width:1px,color:#062;
+  classDef tier2 fill:#F1F8FF,stroke:#1E66F5,stroke-width:1px,color:#123A7D;
+  classDef tier3 fill:#FFF5E6,stroke:#FF8C00,stroke-width:1px,color:#7A3F00;
+  classDef tier4 fill:#FDF0FF,stroke:#9D4EDD,stroke-width:1px,color:#3E1A6D;
+  classDef tier5 fill:#FFF0F0,stroke:#D7263D,stroke-width:1px,color:#6B111B;
+  classDef data fill:#FFFFFF,stroke:#999,stroke-dasharray: 3 3,color:#333;
+
+  %% ========= TIER 1: ESP32 + SENSORS =========
+  subgraph T1[Tier 1 — ESP32 + Sensors<br/>(Leaf Intelligence)]
     direction TB
-    SOLAR["Solar Panel (10W)"] --> CHARGE[Charge Controller]
-    CHARGE --> BATT["Battery (10,000mAh)"]
-    BATT --> DIST[Power Distribution]
-    style PWR fill:#f7fcf0,stroke:#fdae6b
+    SENSORS[[DHT22 • Light • pH • Soil Moisture • Water Level]]
+    ESP32[ESP32 Node<br/>• Sampling 1–5 min<br/>• Rolling stats per window<br/>• Threshold & Δ-rate events<br/>• Monotonic seq<br/>• Optional CRT residues]
+    SENSORS --> ESP32
   end
+  class T1 tier1
+  class SENSORS,ESP32 tier1
 
-  %% ===== SENSING LAYER =====
-  subgraph SNS[Sensing Layer]
+  %% ========= TIER 2: PI GATEWAY =========
+  subgraph T2[Tier 2 — Raspberry Pi Gateway<br/>(Ingest • Verify • Bundle • Schedule)]
     direction TB
-
-    subgraph Z1["Zone 1 (1 km²)"]
-      SM1[Soil Moisture] --> ESP1[ESP32 Node]
-      T1[Temperature] --> ESP1
-      NPK1[NPK Sensor] --> ESP1
-      ESP1 --> |LoRa| GW
-      style Z1 fill:#e6f7ff,stroke:#91d5ff
-    end
-
-    subgraph Z2["Zone 2 (1 km²)"]
-      SM2[Soil Moisture] --> ESP2[ESP32 Node]
-      T2[Temperature] --> ESP2
-      NPK2[NPK Sensor] --> ESP2
-      ESP2 --> |LoRa| GW
-      style Z2 fill:#e6f7ff,stroke:#91d5ff
-    end
-
-    ZN[Zone N] --> |LoRa| GW
-    style SNS fill:#f0f9e8,stroke:#43a2ca
+    INGRESS[IngressService<br/>• Verify HMAC/Ed25519<br/>• Dedupe (device_id, seq)<br/>• CRT recombination (Garner)]
+    BUNDLER[Bundler<br/>• IntervalBundle (30–120 min)<br/>• Event coalesce (60–120 s)<br/>• Rate-limit events]
+    SOF[StoreAndForward<br/>• Durable queue in STORE_DIR<br/>• Retry with backoff]
+    SCHED[Scheduler<br/>• Submit IntervalBundle on cadence<br/>• Submit EventBundle immediately]
+    INGRESS --> BUNDLER --> SCHED
+    BUNDLER --> SOF
   end
+  class T2 tier2
+  class INGRESS,BUNDLER,SOF,SCHED tier2
 
-  %% ===== EDGE PROCESSING LAYER =====
-  subgraph EDGE[Edge Processing Layer]
+  %% ========= TIER 3: MESH (WokFi + BATMAN) =========
+  subgraph T3[Tier 3 — Pi⇄Pi Mesh Network<br/>(WokFi Directional + BATMAN-adv L2 Mesh)]
     direction TB
-    GW[Gateway RPi] --> BUF[Buffer]
-    BUF --> FE[Feature Extractor]
-    FE --> CRT[CRT Compressor]
-    CRT --> SIG[RSA-CRT Signer]
-    SIG --> LORA[LoRa Transmitter]
+    MESH[Mesh (bat0)<br/>• Self-healing L2<br/>• 2–5 ms/hop • Tens of Mbps<br/>• WPA2/3 + WireGuard overlay]
+    MON[MeshMonitor (batctl)<br/>• Neighbors • ETX • Path changes]
+  end
+  class T3 tier3
+  class MESH,MON tier3
 
-    subgraph FE[Feature Extractor]
-      MIN[min]:::feat
-      MAX[max]:::feat
-      MEAN[mean]:::feat
-      STD[std]:::feat
-      PERC[p90]:::feat
-      ANOM[anomaly_flag]:::feat
-      style FE fill:#e6f7ff,stroke:#91d5ff
-    end
+  %% ========= TIER 4: BLOCKCHAIN (FABRIC) =========
+  subgraph T4[Tier 4 — Blockchain (Hyperledger Fabric)]
+    direction TB
+    ORDERER[Orderer(s) — Raft<br/>• 1–3 nodes<br/>• Receives bundled tx]
+    PEERS[Peers on Pis<br/>• Validate & Commit<br/>• CouchDB indexes (device, window, ts)]
+    CC[Chaincode<br/>Keys:<br/>• reading:device_id:window_id → {min,avg,max,std,count,last_ts,residues_hash?,writer_msp}<br/>• event:device_id:ts → {type,before[],after[],thresholds,writer_msp}<br/>Guards:<br/>• last_seq:device_id • Idempotency]
+    BLOCK[Block Structure<br/>• ~100 kB typical (summaries)<br/>• PreferredMaxBytes ≈ 1 MB<br/>• Merkle tree over tx set<br/>• Header {prev_hash, merkle_root, ts}]
+  end
+  class T4 tier4
+  class ORDERER,PEERS,CC,BLOCK tier4
 
-    subgraph CRT[CRT Compressor]
-      R1["res₁ = mean % 65521"]:::code
-      R2["res₂ = std % 65519"]:::code
-      R3["res₃ = (max×10⁴ + min) % 65497"]:::code
-      style CRT fill:#f6ffed,stroke:#b7eb8f
-    end
+  %% ========= TIER 5: OBSERVABILITY / OPS =========
+  subgraph T5[Tier 5 — Observability & Ops]
+    direction TB
+    HEALTH[Health & Readiness<br/>• /healthz (mesh+pipeline)<br/>• /readyz (recent commit)]
+    METRICS[Metrics (Prometheus)<br/>• ingress_packets_total<br/>• bundles_submitted_total{type}<br/>• submit_commit_seconds<br/>• mesh_neighbors, store_backlog_files]
+    DASH[Dashboards / Explorer<br/>• Periodic state view<br/>• Event timeline]
+  end
+  class T5 tier5
+  class HEALTH,METRICS,DASH tier5
 
-    style EDGE fill:#e0f3db,stroke:#43a2ca
+  %% ========= DATA CHANNELS / LABELLED EDGES =========
+  ESP32 -- "Wi-Fi client → Pi SSID\nPayload ≤ ~100 B\nPeriodic Summary (10–15 min) • Event Alert (immediate)\n{device_id, seq, window_id, stats, last_ts, urgent, crt?, sig}" --> INGRESS
+  INGRESS -- "NormalizedRecord\n(sig OK • CRT→value • dedup OK)" --> BUNDLER
+  SCHED -- "Submit IntervalBundle (every 30–120 min)\nSubmit EventBundle (immediate)" --> MESH
+  MESH -- "gRPC over mesh (WireGuard recommended)\nLatency 2–5 ms/hop" --> ORDERER
+  ORDERER -- "Ordered block" --> PEERS
+  PEERS -- "Commit → Chaincode events" --> DASH
+  PEERS -- "Commit events & read-back verify\nsubmit→commit latency" --> HEALTH
+  PEERS -- "Metrics exporter" --> METRICS
+
+  %% ========= NOTES =========
+  note right of ESP32:::data
+    CRT / Modular Arithmetic (optional):
+    • Leaf packs large numbers as residues r_i = x mod m_i
+    • Pi recombines via Garner to recover x
+    • Saves airtime & memory on ESP32
   end
 
-  %% ===== BLOCKCHAIN LAYER =====
-  subgraph BLC[Blockchain Layer]
-    direction LR
-    LORA --> VAL[Validator Node]
-    VAL --> ANC[DailyAnchor Contract]
-    VAL --> ARCH[Archival Node]
-    ARCH --> EXT[External HDD]
-    ANC --> HIST[Historical Roots]
-
-    subgraph VAL[Validator Node]
-      PBFT[PBFT Consensus] --> BLOCK[Block Creator]
-      BLOCK --> LEDGER[Distributed Ledger]
-      style VAL fill:#e0ecff,stroke:#6b8cff
-    end
-
-    style BLC fill:#ccebc5,stroke:#43a2ca
+  note right of BLOCK:::data
+    Block parameters:
+    • Block size: ~100 kB typical (summaries); PreferredMaxBytes ≈ 1 MB
+    • Consensus: Raft (1–3 orderers)
+    • Merkle tree: tx hashes → merkle_root in header
+    • Periodic blocks: every 30–120 min (from Scheduler)
+    • Event-triggered blocks: immediate on anomaly
   end
-
-  %% ===== DATA FLOW =====
-  SNS -->|Raw Sensor Data| EDGE
-  EDGE -->|Signed Transactions| BLC
-  PWR -->|Power| SNS
-  PWR -->|Power| EDGE
-  PWR -->|Power| BLC
-
-  %% ===== ANNOTATIONS =====
-  ANNOT1[["LoRa Specs:
-  - Frequency: 868 MHz
-  - Range: 6.2 km
-  - Data Rate: 5.5 kbps
-  - AES-128 Encryption"]] --> LORA
-
-  ANNOT2[["Hyperledger Fabric:
-  - PBFT Consensus
-  - 30–120 min Blocks
-  - Event-triggered writing
-  - Reduced Storage"]] --> VAL
-
-  ANNOT3[["Power Metrics:
-  - 10W per Node
-  - 6h Battery Backup
-  - Solar Recharge"]] --> PWR
-
-  %% ===== STYLES =====
-  classDef feat fill:#f0f9ff,stroke:#69c0ff
-  classDef code fill:#f8f9fa,stroke:#adc6ff
-  classDef annot fill:#fffbe6,stroke:#ffe58f
 ```
 
-### Key Components Explained
+### Tier Descriptions (Deep Dive)
 
-#### 1. Power Layer
-- **Solar Panel**: 10W polycrystalline
-- **Charge Controller**: PWM-based regulation
-- **Battery**: LiFePO₄ 10,000mAh @ 3.2V
-- **Distribution**: 5V DC to all nodes
-- *Runtime*: 6 hours continuous operation
+#### Tier 1 — ESP32 + Sensors (Leaf Intelligence)
+- **Responsibilities:** sample sensors, compute rolling stats per window, and emit threshold or delta-rate events.
+- **Components:** ESP32 microcontroller with attached sensors.
+- **Inputs:** raw sensor readings. **Outputs:** signed payloads with monotonic `seq`, `stats`, `last_ts`, optional CRT residues.
+- **Timing:** sensor sampling every 1–5 min; periodic summary uplink every 10–15 min; event alerts immediately.
+- **Failure Behavior:** buffers minimal state and retries uplink on next interval; sequence gaps detected by gateway.
 
-#### 2. Sensing Layer (Per 1 km² Zone)
-- **Soil Moisture Sensor**: Capacitive V1.2 (±3% accuracy)
-- **Temperature Sensor**: DS18B20 (±0.5°C accuracy)
-- **NPK Sensor**: JXCT-IoT (N/P/K detection)
-- **ESP32**: dual-core 240 MHz, 520 KB RAM
-- **LoRa Module**: SX1278 (20 dBm output)
-- *Reporting Modes*: periodic 30–120 min updates or instant alerts on threshold breaches
+#### Tier 2 — Raspberry Pi Gateway (Ingest • Verify • Bundle • Schedule)
+- **Responsibilities:** verify signatures, deduplicate, recombine CRT residues, bundle records, persist queue, schedule submissions.
+- **Components:** [IngressService](../flask_app/IngressService.md), [Bundler](../flask_app/Bundler.md), [StoreAndForward](../flask_app/StoreAndForward.md), [Scheduler](../flask_app/Scheduler.md).
+- **Inputs:** Wi-Fi payloads from Tier 1. **Outputs:** `IntervalBundle` and `EventBundle` to mesh.
+- **Timing:** bundle summaries every 30–120 min; events coalesced for 60–120 s and rate limited.
+- **Failure Behavior:** [StoreAndForward](../flask_app/StoreAndForward.md) queues to `STORE_DIR` with retry/backoff.
 
-#### 3. Edge Processing Layer
-- **Feature Extractor**:
-  ```python
-  features = {
-    'min': np.min(window),
-    'max': np.max(window),
-    'mean': np.mean(window),
-    'std': np.std(window),
-    'p90': np.percentile(window, 90),
-    'anomaly': 1 if std > 15 else 0
-  }
-  ```
-- **CRT Compressor**:
-  ```c
-  residues[0] = (uint16_t)(mean * 100) % 65521;
-  residues[1] = (uint16_t)(std * 100) % 65519;
-  residues[2] = (uint16_t)((max * 10000) + min) % 65497;
-  ```
-- **RSA-CRT Signer**: 2048-bit keys, 78 ms signing time
-- *Output*: 46-byte signed AgriBlock
+#### Tier 3 — Pi⇄Pi Mesh Network (WokFi + BATMAN)
+- **Responsibilities:** provide low-latency, self-healing transport between gateways and orderers; monitor mesh health.
+- **Components:** BATMAN-adv mesh interface, [MeshMonitor](../flask_app/MeshMonitor.md).
+- **Inputs:** bundles from scheduler. **Outputs:** gRPC traffic toward Fabric orderers.
+- **Timing:** link latency 2–5 ms per hop; throughput tens of Mbps.
+- **Failure Behavior:** automatic reroute on link failure; monitor surfaces neighbor/ETX changes.
 
-#### 4. Blockchain Layer
-- **Validator Node**:
-  - PBFT consensus with 3-phase commit
-  - Block creation every 5 seconds
-- **DailyAnchor Contract**:
-  ```solidity
-  struct DailyRoot {
-    bytes32 merkleRoot;
-    uint256 timestamp;
-    bytes32 prevRoot;
-  }
-  ```
-- **Archival Node**:
-  - RocksDB storage with Zstd compression
-  - Daily rsync to external HDD
-- *Storage Efficiency*: 225 KB/day per 100 zones
+#### Tier 4 — Blockchain (Hyperledger Fabric)
+- **Responsibilities:** order, validate, and commit bundled transactions into blocks.
+- **Components:** Raft [Orderer(s)](https://hyperledger-fabric.readthedocs.io/), Peers, [FabricClient](../flask_app/FabricClient.md), chaincode.
+- **Inputs:** bundled transactions. **Outputs:** committed state and chaincode events.
+- **Timing:** block size ~100 kB; `PreferredMaxBytes ≈ 1 MB`; periodic blocks every 30–120 min; event blocks immediately.
+- **Failure Behavior:** idempotent keys (`last_seq:device_id`); peers retry on transient failures.
 
-### Data Flow Sequence
-1. **Sensing**: 10-second sensor reads → 30-min windows (180 samples)
-2. **Edge Processing**:
-   - Feature extraction → CRT compression → RSA signing
-   - LoRa transmission to gateway
-3. **Blockchain**:
-   - Transaction validation → PBFT consensus → Ledger storage
-   - Daily Merkle root calculation and anchoring
+#### Tier 5 — Observability & Ops
+- **Responsibilities:** expose health/readiness and metrics, present dashboards.
+- **Components:** health server, Prometheus exporter, dashboards.
+- **Inputs:** commit events, mesh stats, bundle counts. **Outputs:** `/healthz`, `/readyz`, metrics (`ingress_packets_total`, `bundles_submitted_total{type}`, `submit_commit_seconds`, `mesh_neighbors`, `store_backlog_files`).
+- **Timing:** health endpoints polled continuously; metrics scraped on Prometheus interval.
+- **Failure Behavior:** degraded health if no recent commit or mesh unhealthy.
 
-### Performance Metrics
-| **Parameter** | **Sensing** | **Edge** | **Blockchain** |
-|---------------|-------------|----------|----------------|
-| Power Draw | 2.1W | 3.5W | 4.2W |
-| Data Output | 1440B/window | 46B/window | 32B/day (root) |
-| Processing Time | N/A | 85 ms | 420 ms |
-| Network Load | 0.5% duty cycle | 12 KB/hr | 8 KB/hr |
+### Data Schemas
 
-### Innovative Features
-1. **Hybrid Compression**:
-   - Temporal downsampling (180:1)
-   - CRT numerical encoding (12:1)
-2. **Fault Tolerance**:
-   - Battery-backed operation during cloud cover
-   - PBFT consensus tolerates 1/3 node failures
-3. **Resource Optimization**:
-   - Anomaly-driven irrigation commands
-   - Solar-powered off-grid deployment
+- **Leaf → Pi Payload** (`≤ ~100 B`):
+  - `device_id`, `seq`, `window_id`, `stats{min,avg,max,std,count}`, `last_ts`, `urgent`, optional `crt{m[],r[]}`, `sig`.
+- **IntervalBundle** fields:
+  - `bundle_id`, `window_id`, list of readings, `created_ts`, `count`.
+- **EventBundle** fields:
+  - `bundle_id`, list of events `{type,before,after,thresholds}`, `created_ts`.
+- **On-chain Keys:**
+  - `reading:device_id:window_id` → summary stats plus optional `residues_hash`.
+  - `event:device_id:ts` → event details.
+  - Summaries reduce storage; raw values recoverable via Merkle proofs and `residues_hash`.
 
-This revised architecture diagram provides complete technical visibility into the AgriCrypt-Chain system, highlighting the power management, sensor-to-blockchain data flow, and cryptographic processing stages essential for large-scale agricultural monitoring. The color-coded layers and annotated specifications enable clear understanding of the system's operation in resource-constrained environments.
+### Consensus & Block Policy
+
+- **Consensus:** Raft; use 1 orderer for ≤10 Pis, 3 orderers for ≥20 Pis.
+- **Block Formation:** scheduler submits periodic bundles every 30–120 min; event bundles trigger immediate blocks.
+- **Typical submit→commit latency:** ~2–3 s (2 Pis), 5–8 s (20 Pis), 15–30 s (100 Pis).
+
+### CRT & Modular Arithmetic (When/Why)
+
+- Leaf optionally encodes large integers as residues `r_i = x mod m_i` with pairwise co‑prime `m[]` whose product spans expected range.
+- Pi recombines via Garner's algorithm; versioned `m[]` allow rotation and validation.
+- Errors in recombination raise alerts and fall back to raw values.
+
+### Security & Ops
+
+- Leaves sign payloads via HMAC or Ed25519; the [device registry](../docs/device_registry.md) maps `device_id` to verification key.
+- Mesh links secured with WPA2/3; WireGuard overlay recommended for end‑to‑end encryption.
+- Health endpoints: `/healthz` checks mesh and pipeline, `/readyz` confirms recent commit; Prometheus metrics expose ingest and mesh stats.
+
+### Cross-checks / To-Dos
+
+- Stubs for gateway services: [IngressService](../flask_app/IngressService.md), [Bundler](../flask_app/Bundler.md), [Scheduler](../flask_app/Scheduler.md), [StoreAndForward](../flask_app/StoreAndForward.md), [FabricClient](../flask_app/FabricClient.md), [MeshMonitor](../flask_app/MeshMonitor.md).
+- Payload schema documented in [`devices/leaf-node/docs/payload.md`](../devices/leaf-node/docs/payload.md); CRT primer in [`docs/crt.md`](../docs/crt.md).
+- Device registry described in [`docs/device_registry.md`](../docs/device_registry.md).
+- CouchDB indexes for `device_id`, `window_id`, `ts` located under `chaincode/sensor/META-INF/statedb/couchdb/indexes/`.
+- Configuration knobs outlined in [`docs/gateway_config.md`](../docs/gateway_config.md).
+
+### Caption & Legend
+
+*Figure 1: Five-Tier, color-separated architecture; arrows label data, transport, and policy.*
+
+| Tier | Color    | Summary |
+|------|----------|---------|
+| Tier 1 | `#E6FFF2` | ESP32 + Sensors (Leaf Intelligence) |
+| Tier 2 | `#F1F8FF` | Raspberry Pi Gateway |
+| Tier 3 | `#FFF5E6` | Pi⇄Pi Mesh Network |
+| Tier 4 | `#FDF0FF` | Blockchain (Hyperledger Fabric) |
+| Tier 5 | `#FFF0F0` | Observability & Ops |


### PR DESCRIPTION
## Summary
- replace three-tier diagram with five-tier Mermaid flowchart covering ESP32, gateway bundling, mesh, Fabric and observability
- document device registry and gateway config knobs; add stub docs for gateway services

## Testing
- `npx -y @mermaid-js/mermaid-cli -i /tmp/fig1.mmd -o /tmp/fig1.svg` *(fails: libatk-1.0.so.0 missing)*
- `pytest tests/test_block_policy.py tests/test_store_and_forward.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a329d2c408832086b1b2fd35403861