### PR TITLE
Add communication and evaluation diagrams

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,4 @@
+# Metrics
+
+This stub documents system metrics exported via Prometheus at `/metrics`.
+Additional details to be filled in later.

--- a/mermaid diagram/figure1_three_tier_system_architecture.md
+++ b/mermaid diagram/figure1_three_tier_system_architecture.md
@@ -3,6 +3,10 @@ Here's the corrected and complete architecture documentation in a GitHub-compati
 
 # Figure 1 — Five-Tier System Architecture (ESP32 → Pi → Mesh → Fabric → Observability)
 
+Related Figures:
+- [Full Communication Scheme (ESP32 ↔ Pi ↔ Mesh ↔ Fabric ↔ Observability)](figure_comm_all_nodes.md)
+- [Evaluation: Energy & Communications Metrics (ESP32 + Pi + Mesh + Fabric)](figure_eval_energy_comm_metrics.md)
+
 This document is a **drop-in replacement** for the previous three-tier figure.  
 It introduces a **five-tier, color-separated** design and embeds **what/how/when** for every hop, plus **block size**, **consensus (Raft)**, **Merkle tree**, and **CRT/modular arithmetic** call-outs.
 

--- a/mermaid diagram/figure_comm_all_nodes.md
+++ b/mermaid diagram/figure_comm_all_nodes.md
@@ -1,0 +1,51 @@
+# Figure — Full Communication Scheme (ESP32 ↔ Pi ↔ Mesh ↔ Fabric ↔ Observability)
+
+Related: [Five-Tier System Architecture](figure1_three_tier_system_architecture.md)
+
+```mermaid
+sequenceDiagram
+    participant ESP32 as ESP32 Node
+    participant PI as Pi (Wi-Fi AP)
+    participant INGRESS as IngressService
+    participant BUNDLER as Bundler
+    participant SCHED as Scheduler
+    participant MESH as Mesh (BATMAN-adv/WireGuard)
+    participant ORDERER as Fabric Orderer (Raft)
+    participant PEERS as Fabric Peers
+    participant CC as Chaincode
+    participant METRICS as Health/Metrics
+    participant DASH as Dashboard/Explorer
+
+    ESP32-->>PI: {device_id, seq, window_id, stats, urgent, [crt?], sig}\nWi-Fi WPA2/3\n1–5 min samples or events
+    Note over ESP32,PI: HMAC/Ed25519\nCRT residues at leaf
+    PI-->>INGRESS: forward payload
+    INGRESS-->>BUNDLER: verify & dedupe\nGarner CRT
+    alt Periodic window
+        BUNDLER-->>SCHED: interval bundle\ncoalesce 30–120 min
+        SCHED-->>MESH: gRPC\nover WireGuard\non cadence
+    else Event flow
+        BUNDLER-->>SCHED: event bundle\ncoalesce 60–120 s
+        SCHED-->>MESH: gRPC\nover WireGuard\nimmediate
+    end
+    MESH-->>ORDERER: L2 mesh hop\nBATMAN-adv
+    ORDERER-->>PEERS: Raft block cut
+    PEERS-->>CC: tx invoke
+    CC-->>METRICS: emit metrics
+    METRICS-->>DASH: HTTP /metrics\n15 s poll
+```
+
+**What is transmitted**
+
+| Hop | Protocol/Layer | Message/Fields | Size target | Timing | Reliability (retry/SOF) |
+| --- | -------------- | -------------- | ----------- | ------ | ----------------------- |
+| ESP32 → Pi | Wi-Fi (WPA2/3) | `{device_id, seq, window_id, stats, urgent, [crt?], sig}` | <100 B | 1–5 min or event | ESP32 retry, HMAC |
+| Pi → Ingress | loopback | same payload | <100 B | immediate | n/a |
+| Ingress → Bundler | in-memory | normalized reading | ~150 B | immediate | n/a |
+| Bundler → Scheduler | in-memory | interval/event bundle metadata | ~1 KB | 30–120 min periodic;<br/>60–120 s event | n/a |
+| Scheduler → Mesh | gRPC over WireGuard | bundle `{bundle_id,…}` | 50–100 KB | cadence or immediate | SOF retry |
+| Mesh → Orderer | BATMAN-adv L2 | Fabric envelope | ~100 KB | cadence or immediate | SOF retry |
+| Orderer → Peers | Raft/gRPC | block `{prev_hash, merkle_root, ts}` | <1 MB | immediate | Fabric retry |
+| Peers → Chaincode | gRPC | tx proposal | ~1 KB | immediate | Fabric retry |
+| Chaincode → Metrics | internal | counters/gauges | n/a | on commit | n/a |
+| Metrics → Dashboard | HTTP | `/metrics` scrape | text | 15 s poll | HTTP retry |
+

--- a/mermaid diagram/figure_eval_energy_comm_metrics.md
+++ b/mermaid diagram/figure_eval_energy_comm_metrics.md
@@ -1,0 +1,65 @@
+# Figure — Evaluation: Energy & Communications Metrics (ESP32 + Pi + Mesh + Fabric)
+
+Related: [Five-Tier System Architecture](figure1_three_tier_system_architecture.md)
+
+## Part A — Metrics Topology
+
+```mermaid
+flowchart LR
+    ESP32((ESP32))
+    INGRESS[Pi Ingress\ningress_packets_total\nduplicates_total]
+    BUNDLER[Bundler/Scheduler\nbundles_submitted_total{type}\nstore_backlog_files\nevents_rate_limited_total]
+    MESH[Mesh\nmesh_neighbors]
+    FABRIC[Fabric submit→commit\nsubmit_commit_seconds]
+    OBS[Observability /metrics]
+
+    ESP32 --> INGRESS --> BUNDLER --> MESH --> FABRIC --> OBS
+```
+
+## Part B — Latency Pipeline
+
+`Latency_total = L_read + L_wifi + L_ingress + L_bundle_wait + L_submit→commit`
+
+```mermaid
+graph LR
+    L_read[L_read]
+    L_wifi[L_wifi\n10–20 ms]
+    L_ingress[L_ingress]
+    L_bundle[L_bundle_wait\n30–120 min periodic\n≈0 event (60–120 s coalesce)]
+    L_sc[L_submit→commit\n1–2 s (2 Pis)\n3–5 s (20 Pis)\n10–15 s (100 Pis)]
+    L_total[Latency_total]
+
+    L_read --> L_wifi --> L_ingress --> L_bundle --> L_sc --> L_total
+```
+
+## Part C — Energy Budgets
+
+### ESP32
+
+| Component | Current (mA) | Time/day | Notes |
+| --- | --- | --- | --- |
+| Sensors sampling | 5 | duty cycle based | per sensor draw |
+| Wi-Fi TX uplink (periodic) | 200 | uplink_period_sec | window summary |
+| Wi-Fi TX uplink (event) | 200 | bursts | immediate events |
+| Deep sleep | 0.01 | remaining | baseline |
+
+Assume 3.3 V supply. Daily energy `E_day ≈ Σ(I_i × t_i) × V`.
+
+### Raspberry Pi
+
+| State | Power (W) | Time/day | Notes |
+| --- | --- | --- | --- |
+| Idle baseline | 2.5 | always | OS + services |
+| Mesh/Wi-Fi6 active | 1.0 | network traffic | BATMAN-adv/WireGuard overhead |
+| Block processing | 1.5 | cadence dependent | bundling & submit | 
+| Logging/monitoring | 0.5 | optional | debug cost |
+
+### Knobs to lower cost
+
+- `sample_period_sec`
+- `uplink_period_sec`
+- event thresholds / hysteresis
+- CRT to reduce airtime
+
+See [metrics documentation](../docs/metrics.md) and [CRT overview](../docs/crt.md) for details.
+


### PR DESCRIPTION
## Summary
- Add sequence diagram capturing full communication scheme from ESP32 to Fabric and observability with hop-by-hop details
- Provide evaluation figure outlining metrics topology, latency pipeline, and energy budgets for ESP32 and Pi
- Cross-link diagrams with existing five-tier architecture and stub metrics doc for references

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a353af23808320b5073d4fd1feeec2