### PR TITLE
enhance mermaid diagrams for comms and metrics

### DIFF
--- a/mermaid diagram/figure_comm_all_nodes.md
+++ b/mermaid diagram/figure_comm_all_nodes.md
@@ -13,10 +13,12 @@ sequenceDiagram
     participant ORDERER as Fabric Orderer (Raft)
     participant PEERS as Fabric Peers
     participant CC as Chaincode
-    participant METRICS as Health/Metrics
+    participant METRICS as Metrics Exporter
+    participant PROM as Prometheus
     participant DASH as Dashboard/Explorer
 
     ESP32-->>PI: {device_id, seq, window_id, stats, urgent, [crt?], sig}\nWi-Fi WPA2/3\n1–5 min samples or events
+    PI-->>ESP32: ACK\nkeepalive/command
     Note over ESP32,PI: HMAC/Ed25519\nCRT residues at leaf
     PI-->>INGRESS: forward payload
     INGRESS-->>BUNDLER: verify & dedupe\nGarner CRT
@@ -31,7 +33,8 @@ sequenceDiagram
     ORDERER-->>PEERS: Raft block cut
     PEERS-->>CC: tx invoke
     CC-->>METRICS: emit metrics
-    METRICS-->>DASH: HTTP /metrics\n15 s poll
+    METRICS-->>PROM: expose /metrics\nHTTP scrape
+    PROM-->>DASH: render graphs\n15 s pull
 ```
 
 **What is transmitted**
@@ -39,6 +42,7 @@ sequenceDiagram
 | Hop | Protocol/Layer | Message/Fields | Size target | Timing | Reliability (retry/SOF) |
 | --- | -------------- | -------------- | ----------- | ------ | ----------------------- |
 | ESP32 → Pi | Wi-Fi (WPA2/3) | `{device_id, seq, window_id, stats, urgent, [crt?], sig}` | <100 B | 1–5 min or event | ESP32 retry, HMAC |
+| Pi → ESP32 | Wi-Fi | ACK/command | <50 B | immediate | WPA retry |
 | Pi → Ingress | loopback | same payload | <100 B | immediate | n/a |
 | Ingress → Bundler | in-memory | normalized reading | ~150 B | immediate | n/a |
 | Bundler → Scheduler | in-memory | interval/event bundle metadata | ~1 KB | 30–120 min periodic;<br/>60–120 s event | n/a |
@@ -47,5 +51,6 @@ sequenceDiagram
 | Orderer → Peers | Raft/gRPC | block `{prev_hash, merkle_root, ts}` | <1 MB | immediate | Fabric retry |
 | Peers → Chaincode | gRPC | tx proposal | ~1 KB | immediate | Fabric retry |
 | Chaincode → Metrics | internal | counters/gauges | n/a | on commit | n/a |
-| Metrics → Dashboard | HTTP | `/metrics` scrape | text | 15 s poll | HTTP retry |
+| Metrics → Prometheus | HTTP | `/metrics` scrape | text | 15 s poll | HTTP retry |
+| Prometheus → Dashboard | HTTP/WebSocket | rendered metrics | text/JSON | on demand | HTTP retry |
 

--- a/mermaid diagram/figure_eval_energy_comm_metrics.md
+++ b/mermaid diagram/figure_eval_energy_comm_metrics.md
@@ -6,14 +6,20 @@ Related: [Five-Tier System Architecture](figure1_three_tier_system_architecture.
 
 ```mermaid
 flowchart LR
-    ESP32((ESP32))
-    INGRESS[Pi Ingress\ningress_packets_total\nduplicates_total]
-    BUNDLER[Bundler/Scheduler\nbundles_submitted_total{type}\nstore_backlog_files\nevents_rate_limited_total]
-    MESH[Mesh\nmesh_neighbors]
-    FABRIC[Fabric submit→commit\nsubmit_commit_seconds]
-    OBS[Observability /metrics]
+    ESP32((ESP32)):::device
+    INGRESS["Pi Ingress\ningress_packets_total\nduplicates_total\nlatency_seconds"]:::pi
+    BUNDLER["Bundler/Scheduler\nbundles_submitted_total&#123;type&#125;\nstore_backlog_files\nevents_rate_limited_total\nbundle_latency_seconds"]:::pi
+    MESH["Mesh\nmesh_neighbors\nmesh_retries_total"]:::network
+    FABRIC["Fabric submit→commit\nsubmit_commit_seconds\ntx_retry_total"]:::fabric
+    OBS["Observability /metrics\nexporter_up\nalert_events_total"]:::observability
 
     ESP32 --> INGRESS --> BUNDLER --> MESH --> FABRIC --> OBS
+
+    classDef device fill:#e0f7fa,stroke:#006064,color:#006064;
+    classDef pi fill:#fff8e1,stroke:#ff6f00,color:#ff6f00;
+    classDef network fill:#e8f5e9,stroke:#2e7d32,color:#2e7d32;
+    classDef fabric fill:#f3e5f5,stroke:#6a1b9a,color:#6a1b9a;
+    classDef observability fill:#fbe9e7,stroke:#d84315,color:#d84315;
 ```
 
 ## Part B — Latency Pipeline
@@ -22,14 +28,15 @@ flowchart LR
 
 ```mermaid
 graph LR
-    L_read[L_read]
-    L_wifi[L_wifi\n10–20 ms]
-    L_ingress[L_ingress]
+    L_read[L_read\nsensor sampling]
+    L_wifi[L_wifi\n10–20 ms\ntransmit over Wi-Fi]
+    L_ingress[L_ingress\npacket processing]
     L_bundle[L_bundle_wait\n30–120 min periodic\n≈0 event (60–120 s coalesce)]
+    L_sched[L_scheduler\nscheduling latency]
     L_sc[L_submit→commit\n1–2 s (2 Pis)\n3–5 s (20 Pis)\n10–15 s (100 Pis)]
     L_total[Latency_total]
 
-    L_read --> L_wifi --> L_ingress --> L_bundle --> L_sc --> L_total
+    L_read --> L_wifi --> L_ingress --> L_bundle --> L_sched --> L_sc --> L_total
 ```
 
 ## Part C — Energy Budgets


### PR DESCRIPTION
## Summary
- fix metrics topology diagram parsing and add color-coded roles
- expand latency pipeline with scheduling stage
- refine full communication sequence with acknowledgements and Prometheus flow

## Testing
- `pytest`
- `npx -y @mermaid-js/mermaid-cli -i /tmp/metrics_topology.mmd -o /tmp/metrics_topology.svg` *(fails: libatk-1.0.so.0 missing)*


------
https://chatgpt.com/codex/tasks/task_e_68a3885ed44c83209479f78ce5856b05