### PR TITLE
docs: refine network metrics diagrams

### DIFF
--- a/mermaid diagram/figure_comm_all_nodes.md
+++ b/mermaid diagram/figure_comm_all_nodes.md
@@ -16,6 +16,8 @@ sequenceDiagram
     participant METRICS as Metrics Exporter
     participant PROM as Prometheus
     participant DASH as Dashboard/Explorer
+    participant ALERTS as Alertmanager
+    participant OP as Operator
 
     ESP32-->>PI: {device_id, seq, window_id, stats, urgent, [crt?], sig}\nWi-Fi WPA2/3\n1–5 min samples or events
     PI-->>ESP32: ACK\nkeepalive/command
@@ -35,6 +37,9 @@ sequenceDiagram
     CC-->>METRICS: emit metrics
     METRICS-->>PROM: expose /metrics\nHTTP scrape
     PROM-->>DASH: render graphs\n15 s pull
+    PROM-->>ALERTS: push alerts
+    ALERTS-->>OP: notify
+    DASH-->>OP: visualize metrics
 ```
 
 **What is transmitted**
@@ -53,4 +58,7 @@ sequenceDiagram
 | Chaincode → Metrics | internal | counters/gauges | n/a | on commit | n/a |
 | Metrics → Prometheus | HTTP | `/metrics` scrape | text | 15 s poll | HTTP retry |
 | Prometheus → Dashboard | HTTP/WebSocket | rendered metrics | text/JSON | on demand | HTTP retry |
+| Prometheus → Alertmanager | HTTP | alert payloads | small | on rule trigger | HTTP retry |
+| Alertmanager → Operator | Email/Webhook | notification | text | on alert | transport retry |
+| Dashboard → Operator | HTTP/WebSocket | visualization updates | text/JSON | on demand | HTTP retry |
 

--- a/mermaid diagram/figure_eval_energy_comm_metrics.md
+++ b/mermaid diagram/figure_eval_energy_comm_metrics.md
@@ -7,11 +7,11 @@ Related: [Five-Tier System Architecture](figure1_three_tier_system_architecture.
 ```mermaid
 flowchart LR
     ESP32((ESP32)):::device
-    INGRESS["Pi Ingress\ningress_packets_total\nduplicates_total\nlatency_seconds"]:::pi
-    BUNDLER["Bundler/Scheduler\nbundles_submitted_total&#123;type&#125;\nstore_backlog_files\nevents_rate_limited_total\nbundle_latency_seconds"]:::pi
-    MESH["Mesh\nmesh_neighbors\nmesh_retries_total"]:::network
-    FABRIC["Fabric submit→commit\nsubmit_commit_seconds\ntx_retry_total"]:::fabric
-    OBS["Observability /metrics\nexporter_up\nalert_events_total"]:::observability
+    INGRESS["Pi Ingress\ningress_packets_total\nduplicates_total\ndrops_total\nlatency_seconds"]:::pi
+    BUNDLER["Bundler/Scheduler\nbundles_submitted_total\\{type\\}\nstore_backlog_files\nevents_rate_limited_total\nbundle_latency_seconds"]:::pi
+    MESH["Mesh\nmesh_neighbors\nmesh_retries_total\nmesh_rssi_avg"]:::network
+    FABRIC["Fabric submit→commit\nsubmit_commit_seconds\ntx_retry_total\nendorsement_failures_total"]:::fabric
+    OBS["Observability /metrics\nexporter_up\nalert_events_total\nscrape_duration_seconds"]:::observability
 
     ESP32 --> INGRESS --> BUNDLER --> MESH --> FABRIC --> OBS
 
@@ -24,7 +24,7 @@ flowchart LR
 
 ## Part B — Latency Pipeline
 
-`Latency_total = L_read + L_wifi + L_ingress + L_bundle_wait + L_submit→commit`
+`Latency_total = L_read + L_wifi + L_ingress + L_bundle_wait + L_sched + L_mesh + L_submit→commit`
 
 ```mermaid
 graph LR
@@ -33,10 +33,11 @@ graph LR
     L_ingress[L_ingress\npacket processing]
     L_bundle[L_bundle_wait\n30–120 min periodic\n≈0 event (60–120 s coalesce)]
     L_sched[L_scheduler\nscheduling latency]
+    L_mesh[L_mesh\nmesh hop latency]
     L_sc[L_submit→commit\n1–2 s (2 Pis)\n3–5 s (20 Pis)\n10–15 s (100 Pis)]
     L_total[Latency_total]
 
-    L_read --> L_wifi --> L_ingress --> L_bundle --> L_sched --> L_sc --> L_total
+    L_read --> L_wifi --> L_ingress --> L_bundle --> L_sched --> L_mesh --> L_sc --> L_total
 ```
 
 ## Part C — Energy Budgets


### PR DESCRIPTION
## Summary
- fix bundle metric rendering in energy & comms flowchart
- expand communication sequence to include alerting and operator flows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a38d81bf3c83208dda7ee706fefc20