### PR TITLE
docs: add sample sensor data to leaf node

### DIFF
--- a/mermaid diagram/figure1_three_tier_system_architecture.md
+++ b/mermaid diagram/figure1_three_tier_system_architecture.md
@@ -24,7 +24,7 @@ flowchart LR
   %% -------- TIER 1: ESP32 LEAVES --------
   subgraph T1["Tier 1 — ESP32 Leaves"]
     direction TB
-    L1["ESP32\n• sensor_set: temperature, soil_moisture, humidity, soil_ph, light_lux, battery_v, rssi_dbm\n• window stats: {min,avg,max,std,count}\n• flags: urgent\n• optional CRT: m[], r[]\n• sig: Ed25519/HMAC"]:::t1
+    L1["ESP32\n• sensor_set: temperature, soil_moisture, humidity, soil_ph, light_lux, battery_v, rssi_dbm\n• data: temp 25.7°C, moisture 24%, humidity 61%, pH 6.3, lux 2400, battery 3.81V, rssi -78dBm\n• window stats: {min,avg,max,std,count}\n• flags: urgent\n• optional CRT: m[], r[]\n• sig: Ed25519/HMAC"]:::t1
   end
 
   %% -------- TIER 2: PI GATEWAY (INGRESS → BUNDLER) --------


### PR DESCRIPTION
## Summary
- include example sensor readings in Tier 1 leaf node diagram to clarify captured data

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa1bc281f48320aa01132a328e7104