### PR TITLE
Add moduli selection heuristic and document node-memory tradeoffs

### DIFF
--- a/crt_utils.py
+++ b/crt_utils.py
@@ -18,4 +18,20 @@ def crt_value(residues: List[int]) -> float:
     return scaled / 100.0
 
 
-__all__ = ["MODULI", "crt_split", "crt_value"]
+def select_moduli(node_count: int, memory_bytes: int) -> List[int]:
+    """Recommend a CRT moduli set based on network size and device memory.
+
+    The heuristic balances the number of secondary nodes against available
+    memory per device.  Smaller memories use fewer, smaller moduli to reduce
+    residue size, while larger memories can afford a wider numeric range.
+    """
+
+    per_node = memory_bytes // max(1, node_count)
+    if per_node < 32_768:
+        return [97, 101]
+    if per_node < 65_536:
+        return [97, 101, 103]
+    return [97, 101, 103, 107]
+
+
+__all__ = ["MODULI", "crt_split", "crt_value", "select_moduli"]

--- a/mermaid diagram/figure1_three_tier_system_architecture.md
+++ b/mermaid diagram/figure1_three_tier_system_architecture.md
@@ -110,8 +110,12 @@ What each lever changes:
 | Mesh hops | Node spacing, links | \(H \cdot t_h\) term, PDR | `per_hop_latency_ms`, `mesh_neighbors` | Tier 3 |
 | Bundle size | Window length, filters | Queue time \(T_q\), ledger/day | `bundle_latency_seconds`, on-chain bytes/day | Tier 2/4 |
 | CRT on leaf | Budget threshold + moduli set | Packet size, relay count/memory | payload bytes calc, success of Garner recombination | Tier 1/2 |
+| Nodes vs memory | Leaf node count vs RAM/device | Secondary node pressure, residue size | `memory_available_bytes`, latency p95 | Tier 1 |
 
-
+Use performance metrics to balance sensor population against available memory.
+The `select_moduli` utility chooses a threshold moduli set per device:
+<32 KB → `[97,101]`, 32–64 KB → `[97,101,103]`, >64 KB → `[97,101,103,107]`.
+Keeping per-node memory within these bands enables secondary nodes to sustain low latency and low delay.
 
 ### SLOs, Alerts & Readiness Contracts
 

--- a/test_crt_utils.py
+++ b/test_crt_utils.py
@@ -1,0 +1,7 @@
+from crt_utils import select_moduli
+
+
+def test_select_moduli_scales_with_memory():
+    assert select_moduli(10, 100_000) == [97, 101]
+    assert select_moduli(10, 500_000) == [97, 101, 103]
+    assert select_moduli(10, 1_000_000) == [97, 101, 103, 107]


### PR DESCRIPTION
## Summary
- add `select_moduli` utility to choose CRT moduli based on node count and device memory
- document node vs memory tradeoffs and moduli thresholds in architecture diagram
- test moduli selection heuristic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab434591ac83208d4873321f210f32