### PR TITLE
Implement CRT-based sensor pipeline and Merkle bundling

### DIFF
--- a/crt_pipeline.py
+++ b/crt_pipeline.py
@@ -1,0 +1,129 @@
+"""Sensor node and gateway pipeline using CRT compaction.
+
+This module demonstrates how sensor readings can be summarised, optionally
+compressed into Chinese Remainder Theorem (CRT) residues and forwarded to a
+gateway.  The gateway reconstructs the values, aggregates them into a bundle and
+computes a Merkle root suitable for anchoring on a blockchain.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+import statistics
+from typing import Dict, List
+
+from crt_utils import crt_split, crt_value
+
+# Sensor fields included in the demo payloads
+SENSOR_FIELDS = ["temperature", "humidity", "soil_moisture"]
+
+
+@dataclass
+class SensorNode:
+    """Simulated sensor node that produces window summaries."""
+
+    device_id: str
+
+    def summarise(self, readings: List[Dict[str, float]]) -> Dict[str, Dict[str, float]]:
+        """Return per-field statistics for ``readings``.
+
+        ``readings`` is a list of dictionaries with keys from ``SENSOR_FIELDS``.
+        For each field the mean, min, max, standard deviation and count are
+        computed.
+        """
+
+        stats: Dict[str, Dict[str, float]] = {}
+        count = len(readings)
+        for field in SENSOR_FIELDS:
+            values = [r[field] for r in readings]
+            mean = statistics.mean(values)
+            min_v = min(values)
+            max_v = max(values)
+            std = statistics.stdev(values) if count > 1 else 0.0
+            stats[field] = {
+                "mean": mean,
+                "min": min_v,
+                "max": max_v,
+                "std": std,
+                "count": count,
+            }
+        return stats
+
+    def create_payload(self, readings: List[Dict[str, float]], use_crt: bool = True) -> Dict:
+        """Create a payload from ``readings`` with optional CRT compaction."""
+
+        stats = self.summarise(readings)
+        sensors: Dict[str, Dict[str, object]] = {}
+        for field, data in stats.items():
+            if use_crt:
+                sensors[field] = {
+                    "mean": crt_split(data["mean"]),
+                    "min": crt_split(data["min"]),
+                    "max": crt_split(data["max"]),
+                    "std": crt_split(data["std"]),
+                    "count": data["count"],
+                }
+            else:
+                sensors[field] = data
+        return {"device_id": self.device_id, "sensors": sensors}
+
+
+class Gateway:
+    """Gateway that reconstructs readings and computes Merkle roots."""
+
+    def __init__(self, use_crt: bool = True) -> None:
+        self.use_crt = use_crt
+        self.buffer: List[Dict] = []
+
+    def ingest(self, payload: Dict) -> None:
+        """Recombine a sensor payload into floating point values."""
+
+        sensors: Dict[str, Dict[str, float]] = {}
+        for field, data in payload["sensors"].items():
+            if self.use_crt:
+                sensors[field] = {
+                    "mean": crt_value(data["mean"]),
+                    "min": crt_value(data["min"]),
+                    "max": crt_value(data["max"]),
+                    "std": crt_value(data["std"]),
+                    "count": data["count"],
+                }
+            else:
+                sensors[field] = data
+        self.buffer.append({"device_id": payload["device_id"], "sensors": sensors})
+
+    @staticmethod
+    def _hash_record(record: Dict) -> str:
+        blob = json.dumps(record, sort_keys=True).encode()
+        return hashlib.sha256(blob).hexdigest()
+
+    def compute_window(self) -> Dict:
+        """Return bundled readings and their Merkle root."""
+
+        hashes = [self._hash_record(r) for r in self.buffer]
+        root = compute_merkle_root(hashes)
+        bundle = {"readings": self.buffer, "merkle_root": root}
+        self.buffer = []
+        return bundle
+
+
+def compute_merkle_root(hashes: List[str]) -> str:
+    """Compute the Merkle root of a list of hexadecimal hashes."""
+
+    if not hashes:
+        return ""
+    level = hashes[:]
+    while len(level) > 1:
+        if len(level) % 2 == 1:
+            level.append(level[-1])
+        next_level = []
+        for i in range(0, len(level), 2):
+            joined = level[i] + level[i + 1]
+            next_level.append(hashlib.sha256(joined.encode()).hexdigest())
+        level = next_level
+    return level[0]
+
+
+__all__ = ["SensorNode", "Gateway", "compute_merkle_root", "SENSOR_FIELDS"]

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -67,6 +67,11 @@ from sensor_simulator import build_mapping
 from identity_enrollment import enroll_identity
 from channel_block_retrieval import fetch_channel_block
 from hybrid_lora_network import build_demo_network
+from crt_pipeline import (
+    Gateway as CRTGateway,
+    SensorNode as CRTSensorNode,
+    compute_merkle_root as _compute_crt_merkle_root,
+)
 
 # Load gateway orchestrator components from the adjacent module so this file
 # serves as the main import point for both the legacy Flask endpoints and the
@@ -90,6 +95,11 @@ Scheduler = _orch.Scheduler
 HealthServer = _orch.HealthServer
 hmac_sha256 = _orch.hmac_sha256
 main = _orch.main
+
+# Re-export CRT pipeline utilities for external consumers
+SensorNode = CRTSensorNode
+Gateway = CRTGateway
+compute_crt_merkle_root = _compute_crt_merkle_root
 
 
 def create_app(config: dict | None = None) -> Flask:

--- a/test_crt_pipeline.py
+++ b/test_crt_pipeline.py
@@ -1,0 +1,39 @@
+import hashlib
+import json
+
+from crt_pipeline import SensorNode, Gateway
+
+
+def _truncate(val: float) -> float:
+    return int(val * 100) / 100.0
+
+
+def test_roundtrip_and_merkle():
+    readings = [
+        {"temperature": 20.0, "humidity": 55.0, "soil_moisture": 40.0},
+        {"temperature": 22.0, "humidity": 50.0, "soil_moisture": 42.0},
+        {"temperature": 24.0, "humidity": 53.0, "soil_moisture": 41.0},
+    ]
+    node = SensorNode("node1")
+    stats = node.summarise(readings)
+    payload = node.create_payload(readings, use_crt=True)
+    gw = Gateway(use_crt=True)
+    gw.ingest(payload)
+    bundle = gw.compute_window()
+
+    # Expected record after truncation to two decimals
+    expected = {"device_id": "node1", "sensors": {}}
+    for field, data in stats.items():
+        expected["sensors"][field] = {
+            "mean": _truncate(data["mean"]),
+            "min": _truncate(data["min"]),
+            "max": _truncate(data["max"]),
+            "std": _truncate(data["std"]),
+            "count": data["count"],
+        }
+
+    blob = json.dumps(expected, sort_keys=True).encode()
+    expected_root = hashlib.sha256(blob).hexdigest()
+
+    assert bundle["readings"][0] == expected
+    assert bundle["merkle_root"] == expected_root


### PR DESCRIPTION
## Summary
- add `SensorNode` and `Gateway` classes implementing CRT compaction and Merkle root bundling
- provide unit test demonstrating round-trip reconstruction and Merkle root verification
- expose CRT pipeline utilities through the Flask app for downstream use

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf2b23508c8320bc623fc3e9a5f2a7